### PR TITLE
Add payment providers and auth token handling

### DIFF
--- a/src/app/setupAccount/pages/Stage3.tsx
+++ b/src/app/setupAccount/pages/Stage3.tsx
@@ -1,31 +1,57 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import Image from 'next/image'
 import preferencesIcon from '../../../../public/preferences-icon.svg'
 import arrow from '../../../../public/down-arrow.svg'
-import banks from '../thirdStage/utils/banks'
 import { Button } from '../components/Button'
 import { SetupAccountPayload } from '../../../features/user/models/setupAccount'
+import { usePaymentProviders, PaymentProvider } from '../../../features/paymentMethod/hooks/usePaymentProviders'
 
 interface Stage3Props {
     onFinish: (data: Partial<SetupAccountPayload>) => void;
 }
 
+type ProviderType = 'MOBILE' | 'PLATFORM' | 'BANK';
+
 export default function Stage3({ onFinish }: Stage3Props) {
-    const [bank, setBank] = useState(banks[0]);
-    const [accountHolder, setAccountHolder] = useState('');
-    const [accountNumber, setAccountNumber] = useState('');
-    const [open, setOpen] = useState(false);
+    const { providers, loading } = usePaymentProviders();
+    
+    // UI State
+    const [selectedType, setSelectedType] = useState<ProviderType>('BANK');
+    const [selectedProvider, setSelectedProvider] = useState<PaymentProvider | null>(null);
+    const [dynamicFields, setDynamicFields] = useState<Record<string, string>>({});
+    const [isProviderListOpen, setIsProviderListOpen] = useState(false);
+
+    // Filtered providers based on type
+    const filteredProviders = useMemo(() => {
+        return providers.filter(p => p.type === selectedType);
+    }, [providers, selectedType]);
+
+    // Reset provider if type changes
+    useEffect(() => {
+        setSelectedProvider(null);
+        setDynamicFields({});
+    }, [selectedType]);
+
+    const handleFieldChange = (field: string, value: string) => {
+        setDynamicFields(prev => ({ ...prev, [field]: value }));
+    };
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
+        if (!selectedProvider) return;
+
         onFinish({
-            bankName: bank,
-            accountHolderName: accountHolder,
-            accountNumber: accountNumber
+            providerId: selectedProvider.provider_id,
+            accountIdentifier: dynamicFields['account_identifier'],
+            identificationNumber: dynamicFields['identification_number'],
+            beneficiaryName: dynamicFields['beneficiary_name'],
+            description: dynamicFields['description']
         });
     }
+
+    if (loading) return <div className="text-white text-center">Loading providers...</div>;
 
     return (
         <form onSubmit={handleSubmit} className='flex flex-col gap-8'>
@@ -35,68 +61,105 @@ export default function Stage3({ onFinish }: Stage3Props) {
                         <p className='font-bold text-[#BCED09] uppercase text-[10px]'>Recommended for P2P</p>
                     </section>
                 </div>
+                
                 <div className="flex flex-col items-start gap-2">
                     <div className='flex gap-3'>
-                        <Image
-                            src={preferencesIcon}
-                            width={20}
-                            height={20}
-                            alt='icono de p2p setup'
-                        />
+                        <Image src={preferencesIcon} width={20} height={20} alt='p2p setup icon' />
                         <p className="text-[#F1F5F9] font-bold text-[20px]">3. Optional P2P Setup</p>
                     </div>
                     <p className='text-[14px] text-[#94A3B8]'>Add your primary payment method to start peer-to-peer trading.</p>
                 </div>
 
+                {/* 1. Category Slider/Tabs */}
+                <div className="flex flex-col gap-2">
+                    <p className="text-[#CBD5E1] text-sm font-semibold px-1">Method Classification</p>
+                    <div className="flex bg-[#01030880] p-1 rounded-xl border border-[#343434]">
+                        {(['BANK', 'PLATFORM', 'MOBILE'] as ProviderType[]).map((type) => (
+                            <button
+                                key={type}
+                                type="button"
+                                onClick={() => setSelectedType(type)}
+                                className={`flex-1 py-2 text-sm font-bold rounded-lg transition-all ${
+                                    selectedType === type 
+                                    ? 'bg-[#BCED09] text-[#12141A]' 
+                                    : 'text-[#94A3B8] hover:text-white'
+                                }`}
+                            >
+                                {type}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {/* 2. Provider Selector */}
                 <div className="relative">
-                    <p className="text-[#CBD5E1] text-sm font-semibold mb-2 px-1">Payment Method</p>
+                    <p className="text-[#CBD5E1] text-sm font-semibold mb-2 px-1">Select Provider</p>
                     <div
                         className="relative bg-[#01030880] border border-[#343434] rounded-xl px-5 py-4 cursor-pointer"
-                        onClick={() => setOpen(!open)}
+                        onClick={() => setIsProviderListOpen(!isProviderListOpen)}
                     >
-                        <span className="text-[#F1F5F9] text-[16px]">{bank}</span>
-                        <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-gray-400">
-                            <Image src={arrow} width={24} height={24} alt="flecha del select" />
+                        <span className="text-[#F1F5F9] text-[16px]">
+                            {selectedProvider ? selectedProvider.name : `Select a ${selectedType.toLowerCase()} provider...`}
+                        </span>
+                        <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2">
+                            <Image src={arrow} width={24} height={24} alt="arrow" className={isProviderListOpen ? 'rotate-180 transition-transform' : 'transition-transform'} />
                         </div>
                     </div>
-                    {open && (
-                        <div className="absolute z-10 w-full mt-1 bg-[#1a1d27] rounded-xl overflow-hidden border border-white/10">
-                            {banks.map((b) => (
-                                <div
-                                    key={b}
-                                    onClick={() => { setBank(b); setOpen(false); }}
-                                    className={`px-5 py-3 text-[16px] cursor-pointer hover:bg-white/10 transition-colors ${bank === b ? 'text-[#BCED09]' : 'text-[#F1F5F9]'}`}
-                                >
-                                    {b}
-                                </div>
-                            ))}
+                    {isProviderListOpen && (
+                        <div className="absolute z-10 w-full mt-1 bg-[#1a1d27] rounded-xl overflow-hidden border border-white/10 shadow-2xl">
+                            {filteredProviders.length > 0 ? (
+                                filteredProviders.map((p) => (
+                                    <div
+                                        key={p.provider_id}
+                                        onClick={() => { setSelectedProvider(p); setIsProviderListOpen(false); }}
+                                        className={`px-5 py-3 text-[16px] cursor-pointer hover:bg-white/10 transition-colors ${selectedProvider?.provider_id === p.provider_id ? 'text-[#BCED09]' : 'text-[#F1F5F9]'}`}
+                                    >
+                                        {p.name}
+                                    </div>
+                                ))
+                            ) : (
+                                <div className="px-5 py-3 text-[#94A3B8] text-sm italic text-center">No providers found for this category.</div>
+                            )}
                         </div>
                     )}
                 </div>
 
-                <div className="flex flex-col gap-1">
-                    <label className="text-[#CBD5E1] font-semibold text-sm">Account Holder Name</label>
-                    <input
-                        type="text"
-                        value={accountHolder}
-                        onChange={(e) => setAccountHolder(e.target.value)}
-                        placeholder="Full Legal Name"
-                        className="bg-[#01030880] text-[#F1F5F9] text-[16px] rounded-xl px-4 py-3 outline-none border border-[#343434] focus:border-[#BCED09]"
-                    />
-                </div>
-
-                <div className="flex flex-col gap-1">
-                    <label className="text-[#CBD5E1] font-semibold text-sm">IBAN / Account Number</label>
-                    <input
-                        type="text"
-                        value={accountNumber}
-                        onChange={(e) => setAccountNumber(e.target.value)}
-                        placeholder="EX00 0000 0000..."
-                        className="bg-[#01030880] text-[#F1F5F9] text-[16px] rounded-xl px-4 py-3 outline-none border border-[#343434] focus:border-[#BCED09]"
-                    />
-                </div>
+                {/* 3. Dynamic Fields with Animation */}
+                {selectedProvider && (
+                    <div className="flex flex-col gap-5 animate-slide-down overflow-hidden origin-top">
+                        {selectedProvider.metadata.ui_requirements.map((req) => (
+                            <div key={req.db_field} className="flex flex-col gap-1">
+                                <label className="text-[#CBD5E1] font-semibold text-sm">
+                                    {req.label} {req.required && <span className="text-red-500">*</span>}
+                                </label>
+                                <input
+                                    type={req.type}
+                                    value={dynamicFields[req.db_field] || ''}
+                                    onChange={(e) => handleFieldChange(req.db_field, e.target.value)}
+                                    placeholder={req.placeholder}
+                                    required={req.required}
+                                    className="bg-[#01030880] text-[#F1F5F9] text-[16px] rounded-xl px-4 py-3 outline-none border border-[#343434] focus:border-[#BCED09] transition-all"
+                                />
+                            </div>
+                        ))}
+                    </div>
+                )}
             </div>
-            <Button text='Complete setup' />
+            
+            <Button 
+                text='Complete setup' 
+                disabled={!selectedProvider || selectedProvider.metadata.ui_requirements.some(r => r.required && !dynamicFields[r.db_field])}
+            />
+
+            <style jsx>{`
+                @keyframes slide-down {
+                    from { opacity: 0; transform: translateY(-20px); max-height: 0; }
+                    to { opacity: 1; transform: translateY(0); max-height: 500px; }
+                }
+                .animate-slide-down {
+                    animation: slide-down 0.4s ease-out forwards;
+                }
+            `}</style>
         </form>
     );
 }

--- a/src/features/paymentMethod/hooks/usePaymentProviders.ts
+++ b/src/features/paymentMethod/hooks/usePaymentProviders.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+
+export interface PaymentProvider {
+    provider_id: string;
+    name: string;
+    type: 'MOBILE' | 'PLATFORM' | 'BANK';
+    country_code: string | null;
+    metadata: {
+        ui_requirements: Array<{
+            db_field: string;
+            label: string;
+            type: string;
+            placeholder?: string;
+            required: boolean;
+        }>;
+    };
+}
+
+export function usePaymentProviders() {
+    const [providers, setProviders] = useState<PaymentProvider[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchProviders = async () => {
+            try {
+                const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/payment-providers`); // I need to create this endpoint too
+                if (!response.ok) throw new Error('Failed to fetch providers');
+                const data = await response.json();
+                setProviders(data);
+            } catch (err: any) {
+                setError(err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchProviders();
+    }, []);
+
+    return { providers, loading, error };
+}

--- a/src/features/user/hooks/useUsers.ts
+++ b/src/features/user/hooks/useUsers.ts
@@ -4,11 +4,13 @@ import { useEffect, useState } from "react";
 import { Users } from "../models/users";
 import { CreateUser } from "../models/createUser";
 import { SetupAccountPayload } from "../models/setupAccount";
+import { useUser } from "../presentation/context/UserContext";
 
 export function useUsers() {
     const [users, setUsers] = useState<Users[]>([]);
     const [user, setUser] = useState<Users | null>(null);
     const [userFound, setUserFound] = useState<Record<string, CreateUser>>({})
+    const { accessToken, setAccessToken, setCurrentUser } = useUser();
 
     useEffect(() => {
         fetch(`${process.env.NEXT_PUBLIC_API_URL}/users`)
@@ -97,13 +99,18 @@ export function useUsers() {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
+                    "Authorization": `Bearer ${accessToken}`
                 },
                 body: JSON.stringify(payload),
             })
             if (!res.ok) throw new Error('Setup account error');
-            const data = await res.json();
-            setUser(data);
-            return data;
+            const data = await res.json(); // Data is { user, access_token }
+            
+            // Update context with final user and token
+            setCurrentUser(data.user);
+            setAccessToken(data.access_token);
+            
+            return data.user;
         } catch (error) {
             console.error('Error in setupAccount:', error);
             return null;

--- a/src/features/user/presentation/context/UserContext.tsx
+++ b/src/features/user/presentation/context/UserContext.tsx
@@ -6,6 +6,8 @@ import { Users } from '../../models/users';
 interface UserContextType {
     currentUser: Users | null;
     setCurrentUser: (user: Users | null) => void;
+    accessToken: string | null;
+    setAccessToken: (token: string | null) => void;
     isLoading: boolean;
     setIsLoading: (loading: boolean) => void;
 }
@@ -14,17 +16,22 @@ const UserContext = createContext<UserContextType | undefined>(undefined);
 
 export function UserProvider({ children }: { children: ReactNode }) {
     const [currentUser, setCurrentUser] = useState<Users | null>(null);
+    const [accessToken, setAccessToken] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
 
     // Optional: Load user from localStorage or similar if needed
     useEffect(() => {
-        const stored = localStorage.getItem('ikash_user');
-        if (stored) {
+        const storedUser = localStorage.getItem('ikash_user');
+        const storedToken = localStorage.getItem('ikash_token');
+        if (storedUser) {
             try {
-                setCurrentUser(JSON.parse(stored));
+                setCurrentUser(JSON.parse(storedUser));
             } catch (e) {
                 console.error('Error parsing stored user:', e);
             }
+        }
+        if (storedToken) {
+            setAccessToken(storedToken);
         }
     }, []);
 
@@ -37,8 +44,24 @@ export function UserProvider({ children }: { children: ReactNode }) {
         }
     };
 
+    const handleSetAccessToken = (token: string | null) => {
+        setAccessToken(token);
+        if (token) {
+            localStorage.setItem('ikash_token', token);
+        } else {
+            localStorage.removeItem('ikash_token');
+        }
+    };
+
     return (
-        <UserContext.Provider value={{ currentUser, setCurrentUser: handleSetCurrentUser, isLoading, setIsLoading }}>
+        <UserContext.Provider value={{ 
+            currentUser, 
+            setCurrentUser: handleSetCurrentUser, 
+            accessToken,
+            setAccessToken: handleSetAccessToken,
+            isLoading, 
+            setIsLoading 
+        }}>
             {children}
         </UserContext.Provider>
     );

--- a/src/features/wallet/presentation/context/WalletContext.tsx
+++ b/src/features/wallet/presentation/context/WalletContext.tsx
@@ -43,7 +43,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 
     const router = useRouter();
     const { getOrCreateByWallet } = useUsers();
-    const { setCurrentUser } = useUser();
+    const { setCurrentUser, setAccessToken } = useUser();
 
     const connect = useCallback(async (provider: WalletProvider) => {
         setState((s) => ({ ...s, isLoading: true, error: null }));
@@ -51,9 +51,21 @@ export function WalletProvider({ children }: { children: ReactNode }) {
             const publicKey = await walletService.connect(provider);
             setState({ publicKey, provider, isConnected: true, isLoading: false, error: null });
             
+            // Auth logic: Get temporary JWT
+            const loginRes = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ publicKey }),
+            });
+            if (loginRes.ok) {
+                const { access_token } = await loginRes.json();
+                setAccessToken(access_token);
+            }
+
             // Onboarding logic
             const userAccount = await getOrCreateByWallet(publicKey);
             if (userAccount) {
+                setCurrentUser(userAccount);
                 setCurrentUser(userAccount);
                 if (userAccount.pendingAccountInfo) {
                     router.push("/setupAccount");


### PR DESCRIPTION
Introduce dynamic payment provider support and propagate auth tokens through user context and flows. Added a new usePaymentProviders hook to fetch providers and a revamped Stage3 form to select provider types (BANK/PLATFORM/MOBILE), show filtered providers, render provider-driven dynamic fields, validate required inputs, and show a loading state. Extended UserContext with accessToken persistence and setters (localStorage sync). Updated useUsers to send Authorization header when creating account and to store returned user and access_token into context. WalletContext now exchanges a wallet publicKey for a temporary JWT on connect and stores it in the user context. Note: new API endpoints are expected (/payment-providers and /auth/login).