### PR TITLE
[IKSH-09] Display username and alias in header

### DIFF
--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -16,7 +16,7 @@ export default function SettingsPage() {
         <div className="flex min-h-screen w-full bg-[#010308]">
             <Aside />
             <div className="flex flex-col flex-1 min-w-0">
-                <Header title="SETTINGS" showSearch={false} showUser={false} />
+                <Header title="SETTINGS" showUser={false} />
                 
                 {/* Navigation Tabs */}
                 <div className="flex items-center gap-8 px-12 pt-6 bg-[#0A0D14]/30 border-b border-[#1A1F26]">

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,10 +1,13 @@
+import { HeaderUser } from "./HeaderUser";
+
 type HeaderProps = {
     description?: string;
     title: string;
     name?: string;
+    showUser?: boolean;
 }
 
-export function Header({ description, title, name }: HeaderProps) {
+export function Header({ description, title, name, showUser = true }: HeaderProps) {
     return (
         <div className="flex items-center justify-between px-12 py-4 border-b border-[#1F2937] w-full">
             <div className="uppercase font-bold">
@@ -22,6 +25,8 @@ export function Header({ description, title, name }: HeaderProps) {
                     }
                 </div>
             </div>
+
+            {showUser && <HeaderUser />}
         </div>
     );
 }

--- a/src/app/components/HeaderUser.tsx
+++ b/src/app/components/HeaderUser.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { User } from "lucide-react";
+import { useUser } from "@/features/user/presentation/context/UserContext";
+
+function truncateKey(publicKey: string) {
+    if (publicKey.length <= 11) return publicKey;
+    return `${publicKey.slice(0, 5)}…${publicKey.slice(-4)}`;
+}
+
+export function HeaderUser() {
+    const { currentUser } = useUser();
+
+    if (!currentUser) return null;
+
+    const username = truncateKey(currentUser.publicKey);
+    const alias = currentUser.alias?.trim();
+    const initial = (alias?.[0] ?? currentUser.publicKey?.[0] ?? "").toUpperCase();
+
+    return (
+        <div className="flex items-center gap-3">
+            {/* Mock avatar: user initial with icon fallback */}
+            <div className="flex items-center justify-center w-10 h-10 rounded-full bg-[#374151] text-white text-sm font-semibold shrink-0">
+                {initial || <User size={18} strokeWidth={2} />}
+            </div>
+
+            {/* Identity text — hidden on very small screens */}
+            <div className="hidden sm:flex flex-col min-w-0 max-w-[160px]">
+                <span className="text-white text-sm font-semibold truncate">
+                    {username}
+                </span>
+                {alias && (
+                    <span className="text-[#8F8389] text-xs truncate">
+                        {alias}
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Pull Request Summary

### Related Issue
Closes #36

### Description
The app header did not show the authenticated user's identity. This PR
reintroduces a user identity block (mock avatar + username + alias) in the
header.

- **What problem does this solve?** Users could not tell which account they
  were using from the header.
- **What was implemented?** A self-contained `HeaderUser` component that reads
  the authenticated user from `UserContext` and renders a mock avatar, the
  username, and the alias below it (when present).
- **Why this approach?** Keeping the data lookup inside a small dedicated
  component leaves `Header` presentational and avoids threading user data
  through every page that uses the header.

> **Note on the "incorrect routing to dashboard" criterion:** the broken
> routing came from empty `<a href="">` anchors in the old header user block,
> which were already removed in the earlier *"remove tabs"* change. There is no
> active dashboard-routing bug in the current header. This PR therefore
> reintroduces the identity block as **display-only** (no anchors / navigation),
> so the broken behavior is not brought back. Happy to wire up intentional
> routing (e.g. avatar → `/settings`) if that is what the issue intended.

### Type of Change
- [x] New feature
- [x] UI/UX improvement

---

## Changes Made

- Add `HeaderUser` component: mock avatar (user initial with `lucide-react`
  icon fallback), truncated public key as username, and alias below in
  secondary text styling.
- Hide the alias line when the user has no alias; render nothing when there is
  no authenticated user.
- Re-add the `showUser` prop to `Header` and render the identity block when
  enabled.
- Remove the stale `showSearch` prop that the settings page passed to `Header`
  (it no longer exists on the component and would fail `next build`).

---

## Screenshots / Videos

<!-- Paste the screenshot of the header (avatar + username + alias) here -->

---

## Testing

### How was this tested?
- [x] Tested locally
- [x] Tested on mobile screen size
- [x] Tested on desktop screen size
- [ ] Tested with wallet connected
- [x] Tested without wallet connected
- [ ] Tested API manually
- [ ] Added or updated automated tests
- [x] Not applicable

### Test details
1. Rendered the header with a user that has an alias → avatar initial,
   truncated public key as username, alias shown below in secondary styling.
2. Rendered with a user without an alias → alias line hidden, username still
   shown.
3. Rendered with no authenticated user → identity block not rendered.
4. Resized down to mobile width → text column collapses to avatar only; long
   values truncate with an ellipsis.
5. `npm run build`, `tsc --noEmit` and `eslint` all pass.

---

## Frontend Checklist

- [x] UI matches the expected design or issue requirements
- [x] Responsive behavior was verified
- [ ] Loading states are handled
- [x] Empty states are handled
- [ ] Error states are handled
- [x] No console errors were introduced
- [x] Existing user flow was not broken

---

## Database / Prisma Changes

- [ ] Yes
- [x] No

---

## Environment Variables

- [ ] Yes
- [x] No
