### PR TITLE
refactor: remove direct Horizon API calls and use backend endpoints

### DIFF
--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -581,10 +581,11 @@ function ConnectWalletModal({
         throw new Error("No public key found after connection.");
       }
 
-      const horizonRes = await fetch(
-        `https://horizon-testnet.stellar.org/accounts/${savedKey}`,
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+      const accountRes = await fetch(
+        `${apiUrl}/stellar/balances/${savedKey}`,
       );
-      if (!horizonRes.ok) {
+      if (!accountRes.ok) {
         throw new Error(
           "Account not funded or active on Testnet. Please fund your account via Friendbot before connecting.",
         );

--- a/src/features/wallet/presentation/hooks/useWalletPay.ts
+++ b/src/features/wallet/presentation/hooks/useWalletPay.ts
@@ -30,7 +30,8 @@ export function useWalletPay(publicKey: string | null) {
         setState({ isLoading: true, error: null, success: false });
 
         try {
-            const res = await fetch('http://localhost:3000/stellar/pay', {
+            const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+            const res = await fetch(`${apiUrl}/stellar/pay`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/src/features/wallet/presentation/hooks/useWalletTransaction.ts
+++ b/src/features/wallet/presentation/hooks/useWalletTransaction.ts
@@ -31,7 +31,9 @@ export function useWalletTransactions(publicKey: string | null) {
 
         setState({ transactions: [], isLoading: true, error: null });
 
-        fetch(`http://localhost:3000/stellar/transactions/${publicKey}`)
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+
+        fetch(`${apiUrl}/stellar/transactions/${publicKey}`)
             .then((res) => {
                 if (!res.ok) throw new Error("Transacciones no encontradas");
                 return res.json();


### PR DESCRIPTION
## Description
Migrate the frontend from the deprecated `stellar-sdk` to `@stellar/stellar-sdk`, and confirm the frontend only uses backend endpoints.

## Changes
- Update package.json to use @stellar/stellar-sdk
- Confirm frontend only uses backend /stellar endpoints
close #30 