### PR TITLE
feat(settings): add unique account alias input and validation

### DIFF
--- a/src/app/(protected)/settings/components/ProfileTab.tsx
+++ b/src/app/(protected)/settings/components/ProfileTab.tsx
@@ -7,9 +7,11 @@ import { useUsers } from "@/features/user/hooks/useUsers";
 
 export function ProfileTab() {
     const { currentUser } = useUser();
-    const { updateUser } = useUsers();
+    const { updateUser, checkAliasAvailable } = useUsers();
 
+    const [username, setUsername] = useState("");
     const [alias, setAlias] = useState("");
+    const [aliasError, setAliasError] = useState("");
     const [email, setEmail] = useState("");
     const [bio, setBio] = useState("");
     const [tradeAlerts, setTradeAlerts] = useState(true);
@@ -21,6 +23,7 @@ export function ProfileTab() {
 
     useEffect(() => {
         if (currentUser) {
+            setUsername(currentUser.username || "");
             setAlias(currentUser.alias || "");
             setEmail(currentUser.email || "");
             setBio(currentUser.bio || "");
@@ -32,20 +35,59 @@ export function ProfileTab() {
     const handleSaveProfile = async (e: React.FormEvent) => {
         e.preventDefault();
         if (!currentUser) return;
+        
+        if (alias && !/^[a-z0-9.!_]+$/.test(alias)) {
+            setAliasError("Invalid format. Use lowercase, numbers, and ., !, _");
+            return;
+        }
+        if (aliasError) return;
+
         setIsSaving(true);
         setSaveMessage("");
+        
         try {
-            await updateUser(currentUser.userId, {
-                alias,
+            const payload: any = {
+                username,
                 email,
                 bio,
-            });
+            };
+            if (alias) {
+                payload.alias = alias;
+            }
+
+            await updateUser(currentUser.userId, payload);
             setSaveMessage("Profile saved successfully!");
         } catch (err) {
             setSaveMessage("Error saving profile");
         } finally {
             setIsSaving(false);
             setTimeout(() => setSaveMessage(""), 3000);
+        }
+    };
+
+    const handleAliasChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setAlias(value);
+        setAliasError("");
+
+        if (!value) return;
+
+        const isValid = /^[a-z0-9.!_]+$/.test(value);
+        if (!isValid) {
+            setAliasError("Invalid format. Use lowercase, numbers, and ., !, _");
+            return;
+        }
+
+        // Check availability if it changed from the current one
+        if (value !== currentUser?.alias) {
+            try {
+                const { available } = await checkAliasAvailable(value);
+                if (!available) {
+                    setAliasError("This alias is already taken.");
+                }
+            } catch (err) {
+                console.error("Failed to check alias", err);
+            }
         }
     };
 
@@ -121,13 +163,33 @@ export function ProfileTab() {
                                 </label>
                                 <input
                                     type="text"
-                                    value={alias}
-                                    onChange={(e) => setAlias(e.target.value)}
+                                    value={username}
+                                    onChange={(e) => setUsername(e.target.value)}
                                     placeholder="Enter display name"
                                     className="bg-[#010308] border border-[#1A1F26] rounded-xl px-4 py-3 text-[#F1F5F9] focus:border-[#BCED09] outline-none transition-colors w-full"
                                 />
                             </div>
 
+                            <div className="flex flex-col flex-1 gap-2">
+                                <label className="text-[#8F8389] text-sm font-medium">
+                                    Account Alias
+                                </label>
+                                <input
+                                    type="text"
+                                    value={alias}
+                                    onChange={handleAliasChange}
+                                    placeholder="Enter unique alias"
+                                    className={`bg-[#010308] border rounded-xl px-4 py-3 text-[#F1F5F9] focus:outline-none transition-colors w-full ${
+                                        aliasError ? 'border-red-500 focus:border-red-500' : 'border-[#1A1F26] focus:border-[#BCED09]'
+                                    }`}
+                                />
+                                {aliasError && (
+                                    <span className="text-red-500 text-xs mt-1">{aliasError}</span>
+                                )}
+                            </div>
+                        </div>
+
+                        <div className="flex flex-col md:flex-row gap-6">
                             <div className="flex flex-col flex-1 gap-2">
                                 <label className="text-[#8F8389] text-sm font-medium">
                                     Email Address
@@ -163,7 +225,7 @@ export function ProfileTab() {
                             )}
                             <button
                                 type="submit"
-                                disabled={isSaving}
+                                disabled={isSaving || !!aliasError}
                                 className="bg-[#BCED09] hover:bg-[#d4f53a] text-[#010308] font-bold text-sm px-6 py-3 rounded-xl transition-all duration-200 cursor-pointer disabled:opacity-50"
                             >
                                 {isSaving ? "Saving..." : "Save Changes"}

--- a/src/app/(protected)/settings/components/ProfileTab.tsx
+++ b/src/app/(protected)/settings/components/ProfileTab.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Bell, ShieldCheck, UserCheck, CheckCircle2, Clock3, Monitor, Smartphone, LogOut } from "lucide-react";
 import { useUser } from "@/features/user/presentation/context/UserContext";
 import { useUsers } from "@/features/user/hooks/useUsers";
+import { useNotification } from "@/app/components/NotificationContext";
 
 export function ProfileTab() {
     const { currentUser } = useUser();
     const { updateUser, checkAliasAvailable } = useUsers();
+    const { notify } = useNotification();
 
     const [username, setUsername] = useState("");
     const [alias, setAlias] = useState("");
@@ -20,6 +22,10 @@ export function ProfileTab() {
     const [saveMessage, setSaveMessage] = useState("");
     const [kycLoading, setKycLoading] = useState(false);
     const [kycError, setKycError] = useState<string | null>(null);
+
+    // Refs for debouncing alias check and preventing race conditions
+    const aliasDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const aliasRequestSeqRef = useRef(0);
 
     useEffect(() => {
         if (currentUser) {
@@ -65,10 +71,15 @@ export function ProfileTab() {
         }
     };
 
-    const handleAliasChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleAliasChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
         setAlias(value);
         setAliasError("");
+
+        // Cancel any pending debounced check
+        if (aliasDebounceRef.current) {
+            clearTimeout(aliasDebounceRef.current);
+        }
 
         if (!value) return;
 
@@ -78,18 +89,34 @@ export function ProfileTab() {
             return;
         }
 
-        // Check availability if it changed from the current one
+        // Check availability only if value changed from the saved alias
         if (value !== currentUser?.alias) {
-            try {
-                const { available } = await checkAliasAvailable(value);
-                if (!available) {
-                    setAliasError("This alias is already taken.");
+            // Debounce: wait 500 ms after the user stops typing
+            aliasDebounceRef.current = setTimeout(async () => {
+                // Capture a sequence number so stale responses are discarded
+                aliasRequestSeqRef.current += 1;
+                const seq = aliasRequestSeqRef.current;
+
+                try {
+                    const { available } = await checkAliasAvailable(value);
+
+                    // Ignore if a newer request has already been issued
+                    if (seq !== aliasRequestSeqRef.current) return;
+
+                    if (!available) {
+                        setAliasError("This alias is already taken.");
+                    }
+                } catch (err) {
+                    if (seq !== aliasRequestSeqRef.current) return;
+                    console.error("Failed to check alias", err);
+                    notify(
+                        "error",
+                        "Could not verify alias availability. Please check your connection and try again."
+                    );
                 }
-            } catch (err) {
-                console.error("Failed to check alias", err);
-            }
+            }, 500);
         }
-    };
+    }, [currentUser?.alias, checkAliasAvailable, notify]);
 
     const handleToggleTradeAlerts = async () => {
         if (!currentUser) return;

--- a/src/features/user/hooks/useUsers.ts
+++ b/src/features/user/hooks/useUsers.ts
@@ -87,7 +87,7 @@ export function useUsers() {
 
     const checkAliasAvailable = async (alias: string): Promise<{ available: boolean }> => {
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/available-username?alias=${alias}`)
+            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/validate-alias?alias=${alias}`)
             if (!res.ok) throw new Error('Check alias error');
             return await res.json();
         } catch (error) {

--- a/src/features/user/models/users.ts
+++ b/src/features/user/models/users.ts
@@ -1,6 +1,7 @@
 export interface Users {
     userId: string;
     publicKey: string;
+    username?: string;
     alias?: string;
     email?: string;
     notificationsEnabled: boolean;


### PR DESCRIPTION
### Title:
feat(settings): add unique account alias input and frontend validation

### Description:

**What does this PR do?**
This PR implements the frontend UI and logic for the "Unique Account Alias" feature on the Profile Settings page. It ensures that users can set a unique wallet identifier within the iKash ecosystem while keeping the existing "Display Name" (username) behavior intact and fully functional.

**Key Changes:**
- **UI Implementation**: Added a new `Account Alias` input field to the `ProfileTab` component, positioned alongside the Display Name.
- **State Separation**: Decoupled the original `alias` state from the Display Name. The Display Name now binds to `username` locally, preserving the original behavior, while the new strict Account Alias binds to `alias`.
- **Real-Time Format Validation**: Added rigorous frontend regex validation (`/^[a-z0-9.!_]+$/`) on the `alias` input. It strictly enforces:
  - No spaces.
  - No uppercase letters.
  - Only letters, numbers, and allowed symbols (`.`, `!`, `_`).
- **Availability Check**: Integrated the backend `checkAliasAvailable` hook to ping `/users/validate-alias`, instantly checking if the entered alias is already taken by another user.
- **Error Handling & Protection**: 
  - The UI now renders dynamic red borders and explicit error messages below the input if the format is invalid or the alias is taken.
  - The "Save Changes" button is automatically disabled when validation errors are present to prevent invalid API payloads from being sent.

**Acceptance Criteria Met:**
- [x] Profile Settings page includes an alias input.
- [x] Alias validation exists in the frontend.
- [x] Alias availability is checked using the backend endpoint.
- [x] User can save a valid alias.
- [x] User sees a clear error when the alias format is invalid.
- [x] User sees a clear error when the alias is already taken.


closes #31