### PR TITLE
feat: Connect Send Crypto Form to Backend Flow

### DIFF
--- a/src/app/(protected)/dashboard/components/SendFundsModal.tsx
+++ b/src/app/(protected)/dashboard/components/SendFundsModal.tsx
@@ -1,163 +1,339 @@
 'use client';
 
-import Image from 'next/image'
-
+import Image from 'next/image';
 import { CloseModalProps } from "@/app/utils/closeModalProps";
-import arrow from '../../../../../public/down-arrow.svg'
 import { useState, useEffect } from "react";
 import { useWallet, useWalletBalance, type AssetBalance } from "@/features/wallet";
+import { useSend } from "@/features/wallet/presentation/hooks/useSend";
+
+function truncateAddress(addr: string) {
+    return addr.length > 16 ? `${addr.slice(0, 6)}...${addr.slice(-6)}` : addr;
+}
+
+function getAssetName(a: AssetBalance) {
+    return a.asset_type === "native" ? "XLM" : (a.asset_code || "UNKNOWN");
+}
+
+function getFormattedBalance(a: AssetBalance) {
+    return parseFloat(a.balance).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+}
+
+function AssetIcon({ name, size = 32 }: { name: string; size?: number }) {
+    if (name === "XLM") return <Image src="/xlm.png" alt="XLM" width={size} height={size} className="w-full h-full object-cover" />;
+    if (name === "USDC") return <Image src="/usdc.png" alt="USDC" width={size} height={size} className="w-full h-full object-cover" />;
+    return <span className="text-[10px] font-bold text-white">{name.slice(0, 3)}</span>;
+}
+
+const LOADING_MESSAGES: Partial<Record<string, string>> = {
+    loading: "Resolving & preparing transaction...",
+    signing: "Approve the transaction in your wallet...",
+    submitting: "Submitting to Stellar network...",
+};
 
 export function SendFundsModal({ onClose }: CloseModalProps) {
     const { publicKey } = useWallet();
     const { balances } = useWalletBalance(publicKey);
+    const { state, resolveAndPrepare, confirmSend, reset, backToConfirm } = useSend();
 
-    const defaultAsset: AssetBalance = {
-        asset_type: "native",
-        asset_code: "XLM",
-        asset_issuer: null,
-        balance: "0.00"
+    const defaultAsset: AssetBalance = { asset_type: "native", asset_code: "XLM", asset_issuer: null, balance: "0.00" };
+    const usdcBalance = balances.find(b => b.asset_code === "USDC") ?? null;
+    const sendableAsset: AssetBalance = usdcBalance ?? { asset_type: "credit_alphanum4", asset_code: "USDC", asset_issuer: null, balance: "0.00" };
+
+    const [recipientInput, setRecipientInput] = useState("");
+    const [amount, setAmount] = useState("");
+    const [inputError, setInputError] = useState<string | null>(null);
+
+    const assetName = getAssetName(sendableAsset);
+    const isTransacting = state.step === "loading" || state.step === "signing" || state.step === "submitting";
+
+    const feeNum = state.fee ? parseFloat(state.fee) : 0;
+    const amountNum = parseFloat(amount || "0");
+    const totalNum = amountNum + feeNum;
+    const feeDisplay = feeNum.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+    const totalDisplay = totalNum.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+
+    const handleClose = () => {
+        reset();
+        onClose();
     };
 
-    const currentBalances = balances.length > 0 ? balances : [defaultAsset];
-    const [asset, setAsset] = useState<AssetBalance>(currentBalances[0]);
-    const [isAssetOpen, setIsAssetOpen] = useState(false);
+    const isStellarAddress = (v: string) => /^G[A-Z0-9]{55}$/.test(v);
 
-    useEffect(() => {
-        if (balances.length > 0) {
-            setAsset(balances[0]);
+    const handleReviewSend = () => {
+        const trimmed = recipientInput.trim();
+        if (!trimmed || !amount || parseFloat(amount) <= 0) return;
+        if (!isStellarAddress(trimmed)) {
+            setInputError("Only Stellar addresses (starting with G) are supported right now. Alias resolution is coming soon.");
+            return;
         }
-    }, [balances]);
+        setInputError(null);
+        resolveAndPrepare(trimmed, amount);
+    };
 
-    const getAssetName = (a: AssetBalance) => a.asset_type === "native" ? "XLM" : (a.asset_code || "UNKNOWN");
-    const getFormattedBalance = (a: AssetBalance) => parseFloat(a.balance).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+    const headerTitle =
+        state.step === "success" ? "Transfer Complete" :
+        state.step === "error" ? "Transaction Failed" :
+        state.step === "cancelled" ? "Cancelled" :
+        state.step === "confirm" ? "Confirm Send" :
+        "Send Funds";
+
+    const headerSubtitle =
+        state.step === "form" ? "Instant cross-border crypto transfers." :
+        state.step === "confirm" ? "Review the details before signing." :
+        state.step === "success" ? "Your transfer was successful." :
+        state.step === "error" ? "Something went wrong." :
+        state.step === "cancelled" ? "You declined the transaction." : "";
 
     return (
         <div
             className="fixed inset-0 bg-[black/60] backdrop-blur-sm z-40 flex items-center justify-end"
-            onClick={() => onClose()}
+            onClick={!isTransacting ? handleClose : undefined}
         >
             <div
-                className="bg-[#0D1117F2] h-full w-md p-8 border-r border-white/10"
-                onClick={(e) => e.stopPropagation()}
+                className="bg-[#0D1117F2] h-full w-md p-8 border-r border-white/10 flex flex-col"
+                onClick={e => e.stopPropagation()}
             >
+                {/* Header */}
                 <div className="flex items-center justify-between mb-4">
                     <div className="flex flex-col">
-                        <h2 className="text-white text-[30px] font-bold uppercase">Send Funds</h2>
-                        <p className="text-[#C2C7D0] text-[14px]">Instant cross-border crypto transfers.</p>
+                        <h2 className="text-white text-[30px] font-bold uppercase">{headerTitle}</h2>
+                        {headerSubtitle && <p className="text-[#C2C7D0] text-[14px]">{headerSubtitle}</p>}
                     </div>
-                    <button
-                        onClick={() => onClose()}
-                        className="text-gray-400 hover:text-white transition-colors"
-                    >
-                        <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                        </svg>
-                    </button>
+                    {!isTransacting && (
+                        <button onClick={handleClose} className="text-gray-400 hover:text-white transition-colors">
+                            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    )}
                 </div>
 
                 <div className="w-full h-px mb-6" style={{ background: 'linear-gradient(to right, #BCED0900, #BCED09, #BCED0900)' }} />
 
-                <div className="w-99.75 h-12">
-                    <div className="flex flex-col">
-                        <p className="text-[#C2C7D0] text-[12px] mb-2 uppercase">Recipient Address or Alias</p>
-                        <input type="text" placeholder="alex.ikash"
-                            className="w-87.5 h-13 rounded-sm border border-[#45493233] bg-[#1B1B21] pl-3 text-white"
-                        />
-                        <span className="text-[#C2C7D099] text-[10px] mt-2">Verified iKa$h names are cheaper to send to.</span>
-                    </div>
-                    <div className='mt-3'>
-                        <p className="text-[#C2C7D0] text-[12px] mb-2 uppercase">Select asset</p>
-                        <div className="relative mt-3">
+                {/* Form */}
+                {state.step === "form" && (
+                    <div className="flex flex-col gap-4 flex-1">
+                        <div className="flex flex-col">
+                            <p className="text-[#C2C7D0] text-[12px] mb-2 uppercase">Recipient Address or Alias</p>
+                            <input
+                                type="text"
+                                placeholder="alex.ikash or GXXXXXX..."
+                                value={recipientInput}
+                                onChange={e => { setRecipientInput(e.target.value); setInputError(null); }}
+                                className="w-full rounded-xl border border-[#45493233] bg-[#1B1B21] px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-[#BCED09]"
+                            />
+                            {inputError
+                                ? <span className="text-red-400 text-[11px] mt-2">{inputError}</span>
+                                : <span className="text-[#C2C7D099] text-[10px] mt-2">Verified iKa$h names are cheaper to send to.</span>
+                            }
+                        </div>
 
-                            <div
-                                className="relative bg-[#0D1117] border border-[#1C2128] rounded-xl px-5 py-4 cursor-pointer"
-                                onClick={() => setIsAssetOpen(!isAssetOpen)}
-                            >
-                                <div className='flex items-center gap-3'>
-                                    <div className="w-8 h-8 rounded-full overflow-hidden shrink-0 bg-[#1a2a3a] flex items-center justify-center border border-[#2a2a2a] text-white font-bold text-[10px]">
-                                        {getAssetName(asset) === "XLM" ? (
-                                            <Image src="/xlm.png" alt="XLM" width={32} height={32} className="w-full h-full object-cover" />
-                                        ) : getAssetName(asset) === "USDC" ? (
-                                            <Image src="/usdc.png" alt="USDC" width={32} height={32} className="w-full h-full object-cover" />
-                                        ) : (
-                                            getAssetName(asset).slice(0, 3)
-                                        )}
+                        <div>
+                            <p className="text-[#C2C7D0] text-[12px] mb-2 uppercase">Asset</p>
+                            <div className="bg-[#0D1117] border border-[#1C2128] rounded-xl px-5 py-4">
+                                <div className="flex items-center justify-between">
+                                    <div className="flex items-center gap-3">
+                                        <div className="w-8 h-8 rounded-full overflow-hidden shrink-0 bg-[#1a2a3a] flex items-center justify-center border border-[#2a2a2a]">
+                                            <AssetIcon name="USDC" size={32} />
+                                        </div>
+                                        <div className="flex flex-col">
+                                            <span className="text-[#FFFFFF] text-[14px] font-bold">USDC</span>
+                                            <span className="text-[10px] text-[#C2C7D0] uppercase">Balance: {getFormattedBalance(sendableAsset)}</span>
+                                        </div>
                                     </div>
-                                    <div className='flex flex-col'>
-                                        <span className="text-[#FFFFFF] text-[14px] font-bold">{getAssetName(asset)}</span>
-                                        <span className='text-[10px] text-[#C2C7D0] uppercase'>Balance: {getFormattedBalance(asset)}</span>
-                                    </div>
-                                </div>
-                                <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-gray-400">
-                                    <Image src={arrow} width={24} height={24} alt="flecha del select" />
+                                    <span className="text-[10px] text-[#C2C7D099] uppercase tracking-wide">Only asset supported</span>
                                 </div>
                             </div>
-                            {isAssetOpen && (
-                                <div className="absolute z-10 w-full mt-1 bg-[#1a1d27] rounded-xl overflow-hidden border border-white/10">
-                                    {currentBalances.map((c, idx) => (
-                                        <div
-                                            key={`${getAssetName(c)}-${idx}`}
-                                            onClick={() => {
-                                                setAsset(c);
-                                                setIsAssetOpen(false);
-                                            }}
-                                            className={`px-5 py-3 text-[14px] font-bold cursor-pointer hover:bg-white/10 transition-colors
-                                            ${asset === c ? 'text-[#BCED09]' : 'text-[#FFFFFF]'}`}
-                                        >
-                                            <div className='flex items-center gap-3'>
-                                                <div className="w-7 h-7 rounded-full overflow-hidden shrink-0 bg-[#1a2a3a] flex items-center justify-center border border-[#2a2a2a] text-white font-bold text-[9px]">
-                                                    {getAssetName(c) === "XLM" ? (
-                                                        <Image src="/xlm.png" alt="XLM" width={28} height={28} className="w-full h-full object-cover" />
-                                                    ) : getAssetName(c) === "USDC" ? (
-                                                        <Image src="/usdc.png" alt="USDC" width={28} height={28} className="w-full h-full object-cover" />
-                                                    ) : (
-                                                        getAssetName(c).slice(0, 3)
-                                                    )}
-                                                </div>
-                                                <div className='flex flex-col'>
-                                                    <span>{getAssetName(c)}</span>
-                                                    <span className={`text-[10px] uppercase 
-                                                        ${asset === c ? 'text-[#BCED09]' : 'text-[#C2C7D0]'}`}>
-                                                        Balance: {getFormattedBalance(c)}
-                                                    </span>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
                         </div>
-                        <div className='mt-3'>
-                            <p className="text-[#C2C7D0] text-[12px] mb-2 uppercase">amount to send</p>
-                            <div className="relative mt-3">
+
+                        <div>
+                            <p className="text-[#C2C7D0] text-[12px] mb-2 uppercase">Amount to send</p>
+                            <div className="relative mt-1">
                                 <input
                                     type="number"
                                     placeholder="0.00"
                                     min={0}
-                                    onKeyDown={(e) => ["-", "e", "E"].includes(e.key) && e.preventDefault()}
-                                    className="bg-[#0D1117] w-full border border-[#1C2128] rounded-xl px-5 
-                                        py-4 text-[#F1F5F9] placeholder:text-[#64748B] focus:outline-none 
-                                        focus:ring-2 focus:ring-[#BCED09] [appearance:textfield]
-                                        [&::-webkit-outer-spin-button]:appearance-none
-                                        [&::-webkit-inner-spin-button]:appearance-none"
+                                    value={amount}
+                                    onChange={e => setAmount(e.target.value)}
+                                    onKeyDown={e => ["-", "e", "E"].includes(e.key) && e.preventDefault()}
+                                    className="bg-[#0D1117] w-full border border-[#1C2128] rounded-xl px-5 py-4 text-[#F1F5F9] placeholder:text-[#64748B] focus:outline-none focus:ring-2 focus:ring-[#BCED09] [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                                 />
                                 <div className="absolute inset-y-0 right-5 flex items-center pointer-events-none">
-                                    <span className="text-[14px] text-[#94A3B8] font-bold select-none">
-                                        {getAssetName(asset)}
-                                    </span>
+                                    <span className="text-[14px] text-[#94A3B8] font-bold select-none">{assetName}</span>
                                 </div>
                             </div>
                         </div>
-                        <div className="flex w-full items-center justify-center gap-3 mt-10">
+
+                        <div className="flex w-full items-center justify-center mt-auto pt-4">
                             <button
-                                onClick={() => onClose()}
-                                className="flex-1 bg-[#BCED09] uppercase text-black font-semibold px-4 py-3 rounded-xl hover:bg-[#9ac208] transition-colors"
+                                onClick={handleReviewSend}
+                                disabled={!recipientInput.trim() || !amount || parseFloat(amount) <= 0}
+                                className="flex-1 bg-[#BCED09] uppercase text-black font-semibold px-4 py-3 rounded-xl hover:bg-[#9ac208] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                             >
-                                review & send
+                                Review & Send
                             </button>
                         </div>
                     </div>
-                </div>
+                )}
+
+                {/* Loading / Signing / Submitting */}
+                {isTransacting && (
+                    <div className="flex flex-col items-center justify-center flex-1 gap-5">
+                        <div className="w-12 h-12 border-2 border-[#BCED09] border-t-transparent rounded-full animate-spin" />
+                        <p className="text-[#C2C7D0] text-sm text-center">
+                            {LOADING_MESSAGES[state.step] ?? ""}
+                        </p>
+                    </div>
+                )}
+
+                {/* Confirm */}
+                {state.step === "confirm" && state.recipient && (
+                    <div className="flex flex-col gap-4 flex-1">
+                        <div className="bg-[#0D1117] border border-[#1C2128] rounded-xl p-5">
+                            <p className="text-[#C2C7D0] text-[11px] uppercase mb-3">Sending to</p>
+                            <div className="flex items-center gap-3">
+                                <div className="w-10 h-10 rounded-full bg-[#1a2a3a] flex items-center justify-center border border-[#2a2a2a] text-white font-bold text-sm shrink-0">
+                                    {state.recipient.alias ? state.recipient.alias.slice(0, 2).toUpperCase() : "?"}
+                                </div>
+                                <div className="flex flex-col min-w-0">
+                                    {state.recipient.alias && (
+                                        <span className="text-white font-bold text-sm">{state.recipient.alias}</span>
+                                    )}
+                                    <span className="text-[#C2C7D0] text-[12px] font-mono">
+                                        {truncateAddress(state.recipient.address)}
+                                    </span>
+                                    {!state.recipient.exists && (
+                                        <span className="text-yellow-400 text-[10px] mt-1">No iKash account — sending to raw address</span>
+                                    )}
+                                </div>
+                            </div>
+                            {assetName === "USDC" && !state.recipient.hasUsdcTrustline && (
+                                <div className="mt-3 p-3 bg-yellow-900/20 border border-yellow-500/30 rounded-lg">
+                                    <p className="text-yellow-400 text-[11px]">
+                                        Warning: This recipient may not have a USDC trustline. The transaction may fail.
+                                    </p>
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="bg-[#0D1117] border border-[#1C2128] rounded-xl p-5">
+                            <p className="text-[#C2C7D0] text-[11px] uppercase mb-3">Transaction Details</p>
+                            <div className="space-y-2">
+                                <div className="flex justify-between items-center">
+                                    <span className="text-[#C2C7D0] text-sm">Amount</span>
+                                    <span className="text-white text-sm font-bold tabular-nums">{amount} {assetName}</span>
+                                </div>
+                                <div className="flex justify-between items-center">
+                                    <span className="text-[#C2C7D0] text-sm">iKash Fee (0.3%)</span>
+                                    <span className="text-white text-sm font-bold tabular-nums">{feeDisplay} {assetName}</span>
+                                </div>
+                                <div className="w-full h-px bg-[#1C2128] my-1" />
+                                <div className="flex justify-between items-center">
+                                    <span className="text-[#C2C7D0] text-sm font-semibold">Total Deducted</span>
+                                    <span className="text-[#BCED09] text-sm font-bold tabular-nums">{totalDisplay} {assetName}</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="flex gap-3 mt-auto pt-2">
+                            <button
+                                onClick={reset}
+                                className="flex-1 bg-[#1C2128] uppercase text-white font-semibold px-4 py-3 rounded-xl hover:bg-[#2a2a2a] transition-colors border border-[#2a2a2a]"
+                            >
+                                Back
+                            </button>
+                            <button
+                                onClick={confirmSend}
+                                className="flex-1 bg-[#BCED09] uppercase text-black font-semibold px-4 py-3 rounded-xl hover:bg-[#9ac208] transition-colors"
+                            >
+                                Sign & Send
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                {/* Success */}
+                {state.step === "success" && (
+                    <div className="flex flex-col items-center justify-center flex-1 gap-6">
+                        <div className="w-16 h-16 rounded-full bg-[#BCED09]/10 border border-[#BCED09]/30 flex items-center justify-center">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#BCED09" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                <polyline points="20 6 9 17 4 12" />
+                            </svg>
+                        </div>
+                        <div className="text-center">
+                            <p className="text-[#C2C7D0] text-sm">
+                                {amount} {assetName} sent successfully.
+                            </p>
+                        </div>
+                        {state.txHash && (
+                            <div className="w-full bg-[#0D1117] border border-[#1C2128] rounded-xl p-4">
+                                <p className="text-[#C2C7D0] text-[11px] uppercase mb-2">Transaction Hash</p>
+                                <p className="text-white text-[11px] font-mono break-all">{state.txHash}</p>
+                            </div>
+                        )}
+                        <button
+                            onClick={handleClose}
+                            className="w-full bg-[#BCED09] uppercase text-black font-semibold px-4 py-3 rounded-xl hover:bg-[#9ac208] transition-colors mt-2"
+                        >
+                            Done
+                        </button>
+                    </div>
+                )}
+
+                {/* Error */}
+                {state.step === "error" && (
+                    <div className="flex flex-col items-center justify-center flex-1 gap-6">
+                        <div className="w-16 h-16 rounded-full bg-red-500/10 border border-red-500/30 flex items-center justify-center">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                            </svg>
+                        </div>
+                        {state.errorMessage && (
+                            <p className="text-red-400 text-sm text-center">{state.errorMessage}</p>
+                        )}
+                        <div className="flex gap-3 w-full">
+                            <button
+                                onClick={handleClose}
+                                className="flex-1 bg-[#1C2128] uppercase text-white font-semibold px-4 py-3 rounded-xl hover:bg-[#2a2a2a] transition-colors border border-[#2a2a2a]"
+                            >
+                                Close
+                            </button>
+                            <button
+                                onClick={reset}
+                                className="flex-1 bg-[#BCED09] uppercase text-black font-semibold px-4 py-3 rounded-xl hover:bg-[#9ac208] transition-colors"
+                            >
+                                Try Again
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                {/* Cancelled */}
+                {state.step === "cancelled" && (
+                    <div className="flex flex-col items-center justify-center flex-1 gap-6">
+                        <div className="w-16 h-16 rounded-full bg-yellow-500/10 border border-yellow-500/30 flex items-center justify-center">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                                <line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+                            </svg>
+                        </div>
+                        <p className="text-[#C2C7D0] text-sm text-center">You declined the transaction in your wallet.</p>
+                        <div className="flex gap-3 w-full">
+                            <button
+                                onClick={reset}
+                                className="flex-1 bg-[#1C2128] uppercase text-white font-semibold px-4 py-3 rounded-xl hover:bg-[#2a2a2a] transition-colors border border-[#2a2a2a]"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={backToConfirm}
+                                className="flex-1 bg-[#BCED09] uppercase text-black font-semibold px-4 py-3 rounded-xl hover:bg-[#9ac208] transition-colors"
+                            >
+                                Try Again
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/src/app/(protected)/dashboard/components/WalletDashboard.tsx
+++ b/src/app/(protected)/dashboard/components/WalletDashboard.tsx
@@ -35,21 +35,20 @@ export function WalletDashboard() {
                     Total Balance
                 </p>
 
-                <div className="flex items-end justify-between">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                     <div>
                         <div className="flex items-baseline gap-3">
-                            <span className="text-[72px] font-bold text-white tracking-tight">
+                            <span className="text-[48px] sm:text-[72px] font-bold text-white tracking-tight">
                                 {isLoading ? "..." : error ? "-" : (balance || "0.00")}
                             </span>
-                            <span className="text-[#8F8389] text-[24px] tracking-[-3.6px]">XLM</span>
+                            <span className="text-[#8F8389] text-[20px] sm:text-[24px] tracking-[-3.6px]">XLM</span>
                         </div>
                         {error && <p className="text-red-400 text-xs mt-1">{error}</p>}
                     </div>
 
-                    {/*
-                    <div className="flex gap-3">
-                        <button 
-                            className="flex items-center gap-2 bg-[#bced09] hover:bg-[#d4f53a] text-black text-xs font-bold 
+                    <div className="flex gap-3 shrink-0">
+                        <button
+                            className="flex items-center gap-2 bg-[#bced09] hover:bg-[#d4f53a] text-black text-xs font-bold
                             px-5 py-3 rounded-xl tracking-wider transition-all duration-200 hover:scale-105 active:scale-95"
                             onClick={() => setIsModalOpen(true)}
                         >
@@ -58,7 +57,7 @@ export function WalletDashboard() {
                             </svg>
                             SEND
                         </button>
-                        <button className="flex items-center gap-2 bg-[#2a2a2a] hover:bg-[#333] text-white text-xs font-bold 
+                        <button className="flex items-center gap-2 bg-[#2a2a2a] hover:bg-[#333] text-white text-xs font-bold
                             px-5 py-3 rounded-xl tracking-wider transition-all duration-200 hover:scale-105 active:scale-95 border border-[#3a3a3a]"
                             onClick={() => setIsReceiveModalOpen(true)}
                         >
@@ -67,8 +66,7 @@ export function WalletDashboard() {
                             </svg>
                             RECEIVE
                         </button>
-                    </div> 
-                    */}
+                    </div>
                 </div>
             </div>
             <div className="w-full flex flex-col mb-8">

--- a/src/app/(protected)/dashboard/components/WalletDashboard.tsx
+++ b/src/app/(protected)/dashboard/components/WalletDashboard.tsx
@@ -39,10 +39,10 @@ export function WalletDashboard() {
                     <div>
                         <div className="flex items-baseline gap-3">
 
-                            <span className="text-[48px] sm:text-[72px] font-bold text-white tracking-tight">
+                            <span className="text-[40px] md:text-[72px] font-bold text-white tracking-tight">
                                 {isLoading ? "..." : error ? "-" : (balance || "0.00")}
                             </span>
-                            <span className="text-[#8F8389] text-[20px] sm:text-[24px] tracking-[-3.6px]">XLM</span>
+                            <span className="text-[#8F8389] text-[18px] md:text-[24px] tracking-[-3.6px]">XLM</span>
                         </div>
                         {error && <p className="text-red-400 text-xs mt-1">{error}</p>}
                     </div>

--- a/src/features/wallet/infrastructure/freighter.adapter.ts
+++ b/src/features/wallet/infrastructure/freighter.adapter.ts
@@ -54,7 +54,10 @@ export const freighterAdapter = {
                     ? "Public Global Stellar Network ; September 2015"
                     : "Test SDF Network ; September 2015",
         });
-        if (res?.error) throw new Error(res.error);
+        if (res?.error) {
+            const msg = typeof res.error === "string" ? res.error : (res.error?.message ?? JSON.stringify(res.error));
+            throw new Error(msg);
+        }
         return typeof res === "string"
             ? res
             : res.signedTxXdr || res.signedTransaction || res.signedXDR || res;

--- a/src/features/wallet/presentation/hooks/useSend.ts
+++ b/src/features/wallet/presentation/hooks/useSend.ts
@@ -1,0 +1,156 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { useUser } from "@/features/user/presentation/context/UserContext";
+import { useWallet } from "@/features/wallet";
+
+export type SendStep =
+  | "form"
+  | "loading"
+  | "confirm"
+  | "signing"
+  | "submitting"
+  | "success"
+  | "error"
+  | "cancelled";
+
+export interface RecipientInfo {
+  address: string;
+  alias: string | null;
+  exists: boolean;
+  hasUsdcTrustline: boolean;
+}
+
+export interface SendState {
+  step: SendStep;
+  recipient: RecipientInfo | null;
+  fee: string | null;
+  txHash: string | null;
+  errorMessage: string | null;
+}
+
+export function useSend() {
+  const { accessToken } = useUser();
+  const { signTransaction } = useWallet();
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+  const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "TESTNET";
+  const preparedXdrRef = useRef<string | null>(null);
+
+  const [state, setState] = useState<SendState>({
+    step: "form",
+    recipient: null,
+    fee: null,
+    txHash: null,
+    errorMessage: null,
+  });
+
+  const resolveAndPrepare = useCallback(
+    async (query: string, amount: string) => {
+      setState(s => ({ ...s, step: "loading", errorMessage: null }));
+      preparedXdrRef.current = null;
+
+      try {
+        const headers: Record<string, string> = { "Content-Type": "application/json" };
+        if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+
+        const resolveRes = await fetch(
+          `${apiUrl}/send/resolve?recipient=${encodeURIComponent(query)}`,
+          { headers }
+        );
+        if (!resolveRes.ok) {
+          const body = await resolveRes.json().catch(() => ({}));
+          throw new Error((body as { message?: string })?.message ?? "Could not resolve recipient");
+        }
+        const recipient: RecipientInfo = await resolveRes.json();
+
+        const prepareRes = await fetch(`${apiUrl}/send/prepare`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ recipient: recipient.address, amount }),
+        });
+        if (!prepareRes.ok) {
+          const body = await prepareRes.json().catch(() => ({}));
+          throw new Error((body as { message?: string })?.message ?? "Failed to prepare transaction");
+        }
+        const prepared = await prepareRes.json() as Record<string, string>;
+
+        const xdr = prepared.xdr ?? prepared.unsignedXdr ?? prepared.txXdr ?? prepared.transaction ?? prepared.envelope ?? null;
+        if (!xdr) {
+          console.error("[useSend] prepare response missing XDR field:", prepared);
+          throw new Error("Server response did not include a transaction to sign.");
+        }
+
+        preparedXdrRef.current = xdr;
+        setState(s => ({ ...s, step: "confirm", recipient, fee: prepared.fee ?? null }));
+      } catch (err) {
+        setState(s => ({
+          ...s,
+          step: "error",
+          errorMessage: err instanceof Error ? err.message : "An unexpected error occurred",
+        }));
+      }
+    },
+    [accessToken, apiUrl]
+  );
+
+  const confirmSend = useCallback(async () => {
+    const xdr = preparedXdrRef.current;
+    if (!xdr) {
+      setState(s => ({ ...s, step: "error", errorMessage: "Transaction data missing — please go back and try again." }));
+      return;
+    }
+
+    setState(s => ({ ...s, step: "signing", errorMessage: null }));
+
+    let signedXdr: string;
+    try {
+      signedXdr = await signTransaction(xdr, network);
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message :
+        typeof err === "string" ? err :
+        "Signing failed";
+      const isCancelled = /cancel|decline|reject|denied|user rejected/i.test(msg);
+      setState(s => ({
+        ...s,
+        step: isCancelled ? "cancelled" : "error",
+        errorMessage: isCancelled ? null : msg,
+      }));
+      return;
+    }
+
+    setState(s => ({ ...s, step: "submitting" }));
+    try {
+      const submitHeaders: Record<string, string> = { "Content-Type": "application/json" };
+      if (accessToken) submitHeaders["Authorization"] = `Bearer ${accessToken}`;
+      const submitRes = await fetch(`${apiUrl}/send/submit`, {
+        method: "POST",
+        headers: submitHeaders,
+        body: JSON.stringify({ signedXdr }),
+      });
+      if (!submitRes.ok) {
+        const body = await submitRes.json().catch(() => ({}));
+        throw new Error((body as { message?: string })?.message ?? "Transaction submission failed");
+      }
+      const result: { hash?: string } = await submitRes.json();
+      setState(s => ({ ...s, step: "success", txHash: result.hash ?? null }));
+    } catch (err) {
+      setState(s => ({
+        ...s,
+        step: "error",
+        errorMessage: err instanceof Error ? err.message : "Transaction submission failed",
+      }));
+    }
+  }, [accessToken, apiUrl, signTransaction, network]);
+
+  const reset = useCallback(() => {
+    preparedXdrRef.current = null;
+    setState({ step: "form", recipient: null, fee: null, txHash: null, errorMessage: null });
+  }, []);
+
+  const backToConfirm = useCallback(() => {
+    setState(s => ({ ...s, step: "confirm", errorMessage: null }));
+  }, []);
+
+  return { state, resolveAndPrepare, confirmSend, reset, backToConfirm };
+}


### PR DESCRIPTION
## Pull Request Summary

### Related Issue
Closes #32 

### Description
Connects the existing Send Crypto form to the backend send flow. Previously the "Review & Send" button closed the modal without doing anything. This PR wires up all three backend endpoints (`/send/resolve`, `/send/prepare`, `/send/submit`), adds a multi-step confirmation UI, requests the wallet signature using the connected provider (Freighter or LOBSTR), and handles all result states.

The approach keeps the existing modal shell and adds a state machine (8 steps) inside the hook so each UI view is a simple conditional render — no new routing or pages needed.

### Type of Change

- [x] New feature
- [x] UI/UX improvement
- [x] Backend/API change

---

## Changes Made

- Added `src/features/wallet/presentation/hooks/useSend.ts`, state machine hook managing the full send flow: `form → loading → confirm → signing → submitting → success | error | cancelled`
- Rewrote `SendFundsModal.tsx`: recipient input with Stellar address validation, USDC asset display, recipient confirmation card with fee breakdown (0.3%), wallet signing loading state, and distinct success / error / cancelled screens
- Locked the asset selector to USDC (the only asset currently supported by the backend) to prevent sending the wrong asset silently
- Fixed Freighter adapter error extraction — `res.error` can be an object, which caused the error message to display as `"[object Object]"`
- Made the Send/Receive buttons responsive in `WalletDashboard` — they were off-screen on smaller viewports; layout now stacks vertically on mobile and goes side-by-side from `sm` breakpoint

---

## Screenshots / Videos
https://www.loom.com/share/8a274ab1dd6d4e14b4353a4a6b1d6936

---

## Testing

### How was this tested?

- [x] Tested locally
- [x] Tested on mobile screen size
- [x] Tested on desktop screen size
- [x] Tested with wallet connected
- [x] Tested API manually

### Test details

1. Connect Freighter wallet and navigate to the dashboard
2. Click SEND — modal opens with recipient input, USDC balance, and amount field
3. Enter a non-Stellar address (e.g. an alias) — validation error shown inline, API not called
4. Enter a valid Stellar address and amount → click "Review & Send"
5. Confirm screen shows recipient address, iKash alias (if resolved), 0.3% fee, and total deducted
6. Click "Sign & Send" → Freighter popup opens
7. **Approve** → success screen shows tx hash
8. **Decline / close popup** → cancelled screen shown with "Try Again" option (returns to confirm without re-entering form data)
9. Simulate backend error → error screen shown with backend message and "Try Again" resets to form

---

## Frontend Checklist

- [x] UI matches the expected design or issue requirements
- [x] Responsive behavior was verified
- [x] Loading states are handled
- [x] Empty states are handled
- [x] Error states are handled
- [x] No console errors were introduced
- [x] Existing user flow was not broken

---

## Backend Checklist

- [x] Endpoint behavior was verified
- [x] Request validation was added or preserved
- [x] Error handling was added or preserved
- [x] Existing API behavior was not broken
- [ ] Database/Prisma changes were reviewed
- [x] No secrets, private keys, or sensitive values were committed
- [x] Environment variables were documented if needed

---

## Database / Prisma Changes

- [x] No

---

## Environment Variables

- [x] No

---

## Optional Ikash Traction Support

Before closing this issue, it would really help the Ikash project if contributors could visit:

https://ikash.it.com/

And support us by:

1. Joining the waitlist.
2. Connecting a wallet.

Please mark your status below:

* [x] I joined the waitlist
* [x] I connected a wallet
* [ ] I have not done it yet
* [ ] I prefer not to do it

Thank you for contributing to Ikash.
