### PR TITLE
feat(wallet): add challenge-based auth flow

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,12 @@ import "./globals.css";
 import { NotificationProvider } from "./components/NotificationContext";
 import { UserProvider } from "../features/user/presentation/context/UserContext";
 import { WalletProvider } from "../features/wallet";
+import { Space_Grotesk } from "next/font/google";
+
+const spaceGrotesk = Space_Grotesk({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700']
+});
 
 export const metadata: Metadata = {
   title: "iKash",
@@ -16,7 +22,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="font-sans">
+      <body
+        className={spaceGrotesk.className}
+      >
         <NotificationProvider>
           <UserProvider>
             <WalletProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,12 +3,6 @@ import "./globals.css";
 import { NotificationProvider } from "./components/NotificationContext";
 import { UserProvider } from "../features/user/presentation/context/UserContext";
 import { WalletProvider } from "../features/wallet";
-import { Space_Grotesk } from "next/font/google";
-
-const spaceGrotesk = Space_Grotesk({
-  subsets: ['latin'],
-  weight: ['300', '400', '500', '600', '700']
-});
 
 export const metadata: Metadata = {
   title: "iKash",
@@ -22,9 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={spaceGrotesk.className}
-      >
+      <body className="font-sans">
         <NotificationProvider>
           <UserProvider>
             <WalletProvider>

--- a/src/features/wallet/application/__tests__/wallet.service.test.ts
+++ b/src/features/wallet/application/__tests__/wallet.service.test.ts
@@ -1,88 +1,92 @@
-import { describe, it, expect } from "vitest";
-import { isSignatureCancelled } from "../wallet.service";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isSignatureCancelled, walletService } from "../wallet.service";
+import { freighterAdapter } from "../../infrastructure/freighter.adapter";
+import { lobstrAdapter } from "../../infrastructure/lobstr.adapter";
+
+const fetchMock = vi.fn();
+
+vi.stubGlobal("fetch", fetchMock);
+
+vi.mock("../../infrastructure/freighter.adapter", () => ({
+    freighterAdapter: {
+        isInstalled: vi.fn(),
+        isAllowed: vi.fn(),
+        requestAccess: vi.fn(),
+        getAddress: vi.fn(),
+        signTransaction: vi.fn(),
+        signMessage: vi.fn(),
+    },
+}));
+
+vi.mock("../../infrastructure/lobstr.adapter", () => ({
+    lobstrAdapter: {
+        isInstalled: vi.fn(),
+        getPublicKey: vi.fn(),
+        signTransaction: vi.fn(),
+        signMessage: vi.fn(),
+    },
+}));
 
 describe("isSignatureCancelled", () => {
-    // --- Freighter rejection object (primary code-based detection) ---
-
     it("detects Freighter rejection via code -4", () => {
         const err = { code: -4, message: "The user rejected this request." };
         expect(isSignatureCancelled(err)).toBe(true);
     });
-
-    it("detects Freighter rejection regardless of message text when code is -4", () => {
-        const err = { code: -4, message: "Some other message without keywords" };
-        expect(isSignatureCancelled(err)).toBe(true);
-    });
-
-    // --- Error instances (fallback message-based detection) ---
 
     it("detects Error with 'cancel' in message", () => {
         const err = new Error("User canceled the request");
         expect(isSignatureCancelled(err)).toBe(true);
     });
 
-    it("detects Error with 'reject' in message", () => {
-        const err = new Error("User rejected the request");
-        expect(isSignatureCancelled(err)).toBe(true);
-    });
-
-    it("detects Error with 'declined' in message", () => {
-        const err = new Error("User declined the request");
-        expect(isSignatureCancelled(err)).toBe(true);
-    });
-
-    it("detects Error with mixed case", () => {
-        const err = new Error("USER CANCELED");
-        expect(isSignatureCancelled(err)).toBe(true);
-    });
-
-    // --- Plain objects (fallback message-based detection) ---
-
-    it("detects plain object with cancel message (no code)", () => {
-        const err = { message: "User canceled" };
-        expect(isSignatureCancelled(err)).toBe(true);
-    });
-
-    it("detects plain object with reject message (no code)", () => {
-        const err = { message: "user rejected" };
-        expect(isSignatureCancelled(err)).toBe(true);
-    });
-
-    it("detects plain object with declined message (no code)", () => {
-        const err = { message: "User declined" };
-        expect(isSignatureCancelled(err)).toBe(true);
-    });
-
-    // --- False positives ---
-
     it("returns false for unrelated error with code !== -4", () => {
         const err = { code: 1, message: "Network error" };
         expect(isSignatureCancelled(err)).toBe(false);
     });
+});
 
-    it("returns false for unrelated Error", () => {
-        const err = new Error("Network error");
-        expect(isSignatureCancelled(err)).toBe(false);
+describe("walletService.authenticate", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        fetchMock.mockReset();
+        vi.clearAllMocks();
+        localStorage.setItem("wallet:provider", "freighter");
     });
 
-    it("returns false for a generic object", () => {
-        const err = { foo: "bar" };
-        expect(isSignatureCancelled(err)).toBe(false);
+    it("requests a challenge, signs it, and logs in with the returned token", async () => {
+        fetchMock
+            .mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: "abc123", expiresAt: "2026-07-14T15:00:00.000Z" }) })
+            .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: "jwt-token" }) });
+        vi.mocked(freighterAdapter.signMessage).mockResolvedValueOnce("signed-message");
+
+        const token = await walletService.authenticate("G123");
+
+        expect(token).toBe("jwt-token");
+        expect(vi.mocked(freighterAdapter.signMessage)).toHaveBeenCalledWith("abc123");
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenNthCalledWith(2, "http://localhost:3000/auth/login", expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({ publicKey: "G123", challenge: "abc123", signature: "signed-message" }),
+        }));
     });
 
-    it("returns false for null", () => {
-        expect(isSignatureCancelled(null)).toBe(false);
+    it("stops authentication when the wallet signature is rejected", async () => {
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: "abc123" }) });
+        vi.mocked(freighterAdapter.signMessage).mockRejectedValueOnce({ code: -4, message: "The user rejected this request." });
+
+        await expect(walletService.authenticate("G123")).rejects.toThrow("Wallet signature is required to verify ownership and complete login.");
+        expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it("returns false for undefined", () => {
-        expect(isSignatureCancelled(undefined)).toBe(false);
-    });
+    it("prevents duplicate authentication requests while one is in flight", async () => {
+        fetchMock
+            .mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: "abc123" }) })
+            .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: "jwt-token" }) });
+        vi.mocked(freighterAdapter.signMessage).mockResolvedValueOnce("signed-message");
 
-    it("returns false for a string", () => {
-        expect(isSignatureCancelled("cancel")).toBe(false);
-    });
+        const [first, second] = await Promise.all([walletService.authenticate("G123"), walletService.authenticate("G123")]);
 
-    it("returns false for a number", () => {
-        expect(isSignatureCancelled(42)).toBe(false);
+        expect(first).toBe("jwt-token");
+        expect(second).toBe("jwt-token");
+        expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/features/wallet/application/wallet.service.ts
+++ b/src/features/wallet/application/wallet.service.ts
@@ -6,6 +6,77 @@ import type { WalletProvider } from "../domain/wallet.types";
 const PROVIDER_KEY = "wallet:provider";
 const PUBLICKEY_KEY = "wallet:publicKey";
 
+interface ChallengeResponse {
+    challenge: string;
+    expiresAt?: string;
+}
+
+interface LoginResponse {
+    access_token?: string;
+    token?: string;
+    jwt?: string;
+}
+
+function getApiBaseUrl(): string {
+    return process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+}
+
+function normalizeSignature(signature: string): string {
+    return signature.trim();
+}
+
+function isExpiredChallengeError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+    const lower = message.toLowerCase();
+    return lower.includes("expired") || lower.includes("401") || lower.includes("unauthorized");
+}
+
+let authInFlight: Promise<string> | null = null;
+
+async function requestChallenge(publicKey: string): Promise<ChallengeResponse> {
+    const res = await fetch(`${getApiBaseUrl()}/auth/challenge`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ publicKey }),
+    });
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || "No se pudo solicitar el challenge de autenticación.");
+    }
+
+    return (await res.json()) as ChallengeResponse;
+}
+
+async function requestLogin(publicKey: string, challenge: string, signature: string): Promise<string> {
+    const res = await fetch(`${getApiBaseUrl()}/auth/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ publicKey, challenge, signature }),
+    });
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || "No se pudo completar el inicio de sesión.");
+    }
+
+    const data = (await res.json()) as LoginResponse;
+    return data.access_token || data.token || data.jwt || "";
+}
+
+async function signChallenge(challenge: string): Promise<string> {
+    const provider = localStorage.getItem(PROVIDER_KEY) as WalletProvider | null;
+    if (!provider) throw new Error("No wallet connected");
+
+    if (provider === "freighter") {
+        const signed = await freighterAdapter.signMessage(challenge);
+        return normalizeSignature(signed);
+    }
+
+    const signed = await lobstrAdapter.signMessage(challenge);
+    return normalizeSignature(signed);
+}
+
 export const walletService = {
     //Restaura la sesión desde localStorage sin llamadas a las extensiones
     async restoreSession(): Promise<{ publicKey: string; provider: WalletProvider } | null> {
@@ -69,6 +140,57 @@ export const walletService = {
             return await freighterAdapter.signTransaction(xdr, network);
         } else {
             return await lobstrAdapter.signTransaction(xdr);
+        }
+    },
+
+    async authenticate(publicKey: string): Promise<string> {
+        if (authInFlight) {
+            return authInFlight;
+        }
+
+        authInFlight = (async () => {
+            let currentChallenge = "";
+
+            try {
+                const challengeResponse = await requestChallenge(publicKey);
+                currentChallenge = challengeResponse.challenge;
+
+                for (let attempt = 0; attempt < 2; attempt += 1) {
+                    try {
+                        const signature = await signChallenge(currentChallenge);
+                        const token = await requestLogin(publicKey, currentChallenge, signature);
+                        if (!token) {
+                            throw new Error("La respuesta de autenticación no incluyó un JWT.");
+                        }
+                        return token;
+                    } catch (error) {
+                        if (attempt === 0 && isExpiredChallengeError(error)) {
+                            const freshChallenge = await requestChallenge(publicKey);
+                            currentChallenge = freshChallenge.challenge;
+                            continue;
+                        }
+
+                        if (isSignatureCancelled(error)) {
+                            throw new Error("Wallet signature is required to verify ownership and complete login.");
+                        }
+
+                        throw error;
+                    }
+                }
+
+                throw new Error("No se pudo completar el inicio de sesión.");
+            } catch (error) {
+                if (isSignatureCancelled(error)) {
+                    throw new Error("Wallet signature is required to verify ownership and complete login.");
+                }
+                throw error;
+            }
+        })();
+
+        try {
+            return await authInFlight;
+        } finally {
+            authInFlight = null;
         }
     },
 

--- a/src/features/wallet/application/wallet.service.ts
+++ b/src/features/wallet/application/wallet.service.ts
@@ -42,7 +42,7 @@ async function requestChallenge(publicKey: string): Promise<ChallengeResponse> {
 
     if (!res.ok) {
         const text = await res.text();
-        throw new Error(text || "No se pudo solicitar el challenge de autenticación.");
+        throw new Error(text || "Could not request authentication challenge.");
     }
 
     return (await res.json()) as ChallengeResponse;
@@ -57,7 +57,7 @@ async function requestLogin(publicKey: string, challenge: string, signature: str
 
     if (!res.ok) {
         const text = await res.text();
-        throw new Error(text || "No se pudo completar el inicio de sesión.");
+        throw new Error(text || "Could not complete login.");
     }
 
     const data = (await res.json()) as LoginResponse;
@@ -122,7 +122,7 @@ export const walletService = {
             const installed = await lobstrAdapter.isInstalled();
             if (!installed) throw new Error("LOBSTR no está instalado. Instálalo en https://lobstr.co/signer-extension");
             const key = await lobstrAdapter.getPublicKey();
-            if (!key) throw new Error("No se pudo obtener el public key. Asegúrate de tener la app LOBSTR vinculada.");
+            if (!key) throw new Error("Could not get public key. Make sure you have the LOBSTR app linked.");
             publicKey = key;
         }
 
@@ -160,7 +160,7 @@ export const walletService = {
                         const signature = await signChallenge(currentChallenge);
                         const token = await requestLogin(publicKey, currentChallenge, signature);
                         if (!token) {
-                            throw new Error("La respuesta de autenticación no incluyó un JWT.");
+                            throw new Error("Authentication response did not include a JWT.");
                         }
                         return token;
                     } catch (error) {
@@ -178,7 +178,7 @@ export const walletService = {
                     }
                 }
 
-                throw new Error("No se pudo completar el inicio de sesión.");
+                throw new Error("Could not complete login.");
             } catch (error) {
                 if (isSignatureCancelled(error)) {
                     throw new Error("Wallet signature is required to verify ownership and complete login.");

--- a/src/features/wallet/infrastructure/freighter.adapter.ts
+++ b/src/features/wallet/infrastructure/freighter.adapter.ts
@@ -4,6 +4,7 @@ import {
     requestAccess,
     getAddress,
     signTransaction,
+    signMessage as freighterSignMessage,
 } from "@stellar/freighter-api";
 
 export const freighterAdapter = {

--- a/src/features/wallet/infrastructure/freighter.adapter.ts
+++ b/src/features/wallet/infrastructure/freighter.adapter.ts
@@ -47,6 +47,30 @@ export const freighterAdapter = {
         }
     },
 
+    async signMessage(message: string): Promise<string> {
+        const res = await freighterSignMessage(message);
+
+        if (typeof res === "object" && res !== null && "error" in res && res.error) {
+            const msg = typeof res.error === "string" ? res.error : (res.error?.message ?? JSON.stringify(res.error));
+            throw new Error(msg);
+        }
+
+        const signedMessage = typeof res === "string"
+            ? res
+            : res?.signedMessage;
+
+        if (typeof signedMessage === "string") {
+            return signedMessage.trim();
+        }
+
+        if (signedMessage && typeof signedMessage === "object" && "byteLength" in signedMessage) {
+            const bytes = signedMessage as Uint8Array;
+            return Buffer.from(bytes).toString("base64");
+        }
+
+        throw new Error("No se pudo obtener la firma del mensaje.");
+    },
+
     // Firma una transacción XDR con Freighter
     async signTransaction(xdr: string, network: string = "TESTNET"): Promise<string> {
         type SignResult = string | { signedTxXdr?: string; signedTransaction?: string; signedXDR?: string; error?: string | { message: string } };

--- a/src/features/wallet/infrastructure/freighter.adapter.ts
+++ b/src/features/wallet/infrastructure/freighter.adapter.ts
@@ -68,7 +68,7 @@ export const freighterAdapter = {
             return Buffer.from(bytes).toString("base64");
         }
 
-        throw new Error("No se pudo obtener la firma del mensaje.");
+        throw new Error("Could not get message signature.");
     },
 
     // Firma una transacción XDR con Freighter

--- a/src/features/wallet/infrastructure/lobstr.adapter.ts
+++ b/src/features/wallet/infrastructure/lobstr.adapter.ts
@@ -1,4 +1,4 @@
-import { isConnected, getPublicKey, signTransaction as lobstrSignTransaction } from "@lobstrco/signer-extension-api";
+import { isConnected, getPublicKey, signTransaction as lobstrSignTransaction, signMessage as lobstrSignMessage } from "@lobstrco/signer-extension-api";
 
 export const lobstrAdapter = {
     //Verifica si el usuario tiene la extensión LOBSTR instalada.
@@ -18,6 +18,14 @@ export const lobstrAdapter = {
         } catch {
             return null;
         }
+    },
+
+    async signMessage(message: string): Promise<string> {
+        const res = await lobstrSignMessage(message);
+        if (!res?.signedMessage) {
+            throw new Error("No se pudo obtener la firma del mensaje.");
+        }
+        return res.signedMessage.trim();
     },
 
     // Firma una transacción XDR con LOBSTR

--- a/src/features/wallet/infrastructure/lobstr.adapter.ts
+++ b/src/features/wallet/infrastructure/lobstr.adapter.ts
@@ -23,7 +23,7 @@ export const lobstrAdapter = {
     async signMessage(message: string): Promise<string> {
         const res = await lobstrSignMessage(message);
         if (!res?.signedMessage) {
-            throw new Error("No se pudo obtener la firma del mensaje.");
+            throw new Error("Could not get message signature.");
         }
         return res.signedMessage.trim();
     },

--- a/src/features/wallet/presentation/context/WalletContext.tsx
+++ b/src/features/wallet/presentation/context/WalletContext.tsx
@@ -100,16 +100,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
             }
 
             setState({ publicKey, provider, isConnected: true, isLoading: false, error: null });
-            
-            // Auth logic: Get temporary JWT
-            const loginRes = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ publicKey }),
-            });
-            if (loginRes.ok) {
-                const { access_token } = await loginRes.json();
-                setAccessToken(access_token);
+
+            const token = await walletService.authenticate(publicKey);
+            if (token) {
+                setAccessToken(token);
             }
 
             // Onboarding logic


### PR DESCRIPTION
## Summary

This PR updates the wallet authentication flow to use a backend challenge-response flow before login.

## What changed

- request a challenge from /auth/challenge
- sign the exact challenge with the connected wallet
- submit the public key, challenge, and signature to /auth/login
- prevent duplicate in-flight authentication requests
- surface a clear error when the user rejects wallet signing
- retry once with a fresh challenge when the backend reports an expired or unauthorized challenge

## Testing

- npm test -- wallet.service.test.ts
- npm test

Closes #57