### PR TITLE
feat(orders): add Cancel Order action before payment is marked (#67)

### DIFF
--- a/src/app/(protected)/p2p/orders/[orderId]/page.tsx
+++ b/src/app/(protected)/p2p/orders/[orderId]/page.tsx
@@ -9,8 +9,11 @@ import { EvidencePreview } from "../components/EvidencePreview";
 import { Chat } from "../../components/Chat";
 import { useUser } from "@/features/user/presentation/context/UserContext";
 import type { Order } from "@/features/order/models/order";
-import { useOrders } from "@/features/order/hooks/useOrders";
-import { ArrowLeft, AlertTriangle, Ban, Loader2 } from "lucide-react";
+import { useOrders, ApiError } from "@/features/order/hooks/useOrders";
+import { canCancelOrder } from "@/features/order/utils/canCancelOrder";
+import { CancelOrderModal } from "../components/CancelOrderModal";
+import { useNotification } from "@/app/components/NotificationContext";
+import { ArrowLeft, AlertTriangle, Ban, Loader2, XCircle } from "lucide-react";
 import Link from "next/link";
 
 interface PageProps {
@@ -25,11 +28,14 @@ function restoreUuidDashes(uuid: string): string {
 export default function TradePage({ params }: PageProps) {
     const { orderId } = use(params);
     const { currentUser } = useUser();
-    const { getOrder } = useOrders();
+    const { getOrder, cancelOrder } = useOrders();
+    const { notify } = useNotification();
 
     const [order, setOrder] = useState<Order | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [errorMsg, setErrorMsg] = useState("");
+    const [showCancelModal, setShowCancelModal] = useState(false);
+    const [isCancelling, setIsCancelling] = useState(false);
 
     // Create a demo order object when path is /demo or starting with mock-
     const demoOrder = useMemo((): Order | null => {
@@ -136,6 +142,35 @@ export default function TradePage({ params }: PageProps) {
         }
     }, [currentUser, fetchOrder]);
 
+    const handleCancelOrder = useCallback(async () => {
+        if (!order || orderId === "demo" || orderId.startsWith("mock-")) {
+            setShowCancelModal(false);
+            return;
+        }
+
+        setIsCancelling(true);
+        try {
+            await cancelOrder(order.orderId);
+            setShowCancelModal(false);
+            notify("success", "Order cancelled successfully.");
+            await fetchOrder();
+        } catch (err: unknown) {
+            setShowCancelModal(false);
+            // Backend rejected because the order's state changed underneath
+            // us (e.g. payment was marked while the modal was open) — refresh
+            // to show the latest state instead of leaving a stale UI.
+            if (err instanceof ApiError && err.status === 409) {
+                notify("warning", "This order can no longer be cancelled because its status has changed.");
+                await fetchOrder();
+                return;
+            }
+            const msg = err instanceof Error ? err.message : "Failed to cancel the order. Please try again.";
+            notify("error", msg);
+        } finally {
+            setIsCancelling(false);
+        }
+    }, [order, orderId, cancelOrder, notify, fetchOrder]);
+
     if (!currentUser) {
         return (
             <div className="flex h-screen w-full overflow-hidden bg-[#010308]">
@@ -236,6 +271,7 @@ export default function TradePage({ params }: PageProps) {
 
     const counterpartyUser = isBuyer ? order.seller : order.buyer;
     const isCompleted = order.escrow?.escrowStatus === 'released';
+    const canCancel = canCancelOrder(order, currentUser.userId);
 
     return (
         <div className="flex min-h-screen w-full overflow-hidden bg-[#010308] pb-20 md:pb-0">
@@ -265,9 +301,21 @@ export default function TradePage({ params }: PageProps) {
                                     </>
                                 )}
                             </div>
-                            <h2 className="text-white font-black text-[20px] leading-7 uppercase tracking-normal font-space hidden md:block">
-                                ORDER DETAILS
-                            </h2>
+                            <div className="flex items-center gap-4">
+                                {canCancel && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowCancelModal(true)}
+                                        className="flex items-center gap-1.5 text-[#FF6B6B] hover:text-[#ff8080] text-[12px] font-bold uppercase tracking-[1px] transition-colors cursor-pointer font-space border border-[#FF6B6B]/30 hover:border-[#FF6B6B]/60 rounded-md px-3 py-1.5"
+                                    >
+                                        <XCircle className="w-3.5 h-3.5" />
+                                        Cancel Order
+                                    </button>
+                                )}
+                                <h2 className="text-white font-black text-[20px] leading-7 uppercase tracking-normal font-space hidden md:block">
+                                    ORDER DETAILS
+                                </h2>
+                            </div>
                         </div>
 
                         {/* Contenedor Principal Escalado por Rol */}
@@ -395,6 +443,14 @@ export default function TradePage({ params }: PageProps) {
                     </div>
                 </main>
             </div>
+
+            {showCancelModal && (
+                <CancelOrderModal
+                    onConfirm={handleCancelOrder}
+                    onClose={() => setShowCancelModal(false)}
+                    isCancelling={isCancelling}
+                />
+            )}
         </div>
     );
 }

--- a/src/app/(protected)/p2p/orders/[orderId]/page.tsx
+++ b/src/app/(protected)/p2p/orders/[orderId]/page.tsx
@@ -13,7 +13,7 @@ import { useOrders, ApiError } from "@/features/order/hooks/useOrders";
 import { canCancelOrder } from "@/features/order/utils/canCancelOrder";
 import { CancelOrderModal } from "../components/CancelOrderModal";
 import { useNotification } from "@/app/components/NotificationContext";
-import { ArrowLeft, AlertTriangle, Ban, Loader2, XCircle } from "lucide-react";
+import { ArrowLeft, AlertTriangle, Ban, Loader2 } from "lucide-react";
 import Link from "next/link";
 
 interface PageProps {
@@ -302,16 +302,6 @@ export default function TradePage({ params }: PageProps) {
                                 )}
                             </div>
                             <div className="flex items-center gap-4">
-                                {canCancel && (
-                                    <button
-                                        type="button"
-                                        onClick={() => setShowCancelModal(true)}
-                                        className="flex items-center gap-1.5 text-[#FF6B6B] hover:text-[#ff8080] text-[12px] font-bold uppercase tracking-[1px] transition-colors cursor-pointer font-space border border-[#FF6B6B]/30 hover:border-[#FF6B6B]/60 rounded-md px-3 py-1.5"
-                                    >
-                                        <XCircle className="w-3.5 h-3.5" />
-                                        Cancel Order
-                                    </button>
-                                )}
                                 <h2 className="text-white font-black text-[20px] leading-7 uppercase tracking-normal font-space hidden md:block">
                                     ORDER DETAILS
                                 </h2>
@@ -350,6 +340,9 @@ export default function TradePage({ params }: PageProps) {
                                                 amount={amountVal}
                                                 evidenceUrl={order.escrow?.evidenceUrl}
                                                 onStatusChange={fetchOrder}
+                                                canCancel={canCancel}
+                                                isCancelling={isCancelling}
+                                                onCancelOrder={() => setShowCancelModal(true)}
                                             />
                                         </div>
                                     </div>
@@ -405,6 +398,9 @@ export default function TradePage({ params }: PageProps) {
                                             expiresAt={order.expiresAt as string | undefined}
                                             evidenceUrl={order.escrow?.evidenceUrl}
                                             onStatusChange={fetchOrder}
+                                            canCancel={canCancel}
+                                            isCancelling={isCancelling}
+                                            onCancelOrder={() => setShowCancelModal(true)}
                                         />
                                     </div>
 

--- a/src/app/(protected)/p2p/orders/components/CancelOrderModal.tsx
+++ b/src/app/(protected)/p2p/orders/components/CancelOrderModal.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+interface CancelOrderModalProps {
+    onConfirm: () => void;
+    onClose: () => void;
+    isCancelling: boolean;
+}
+
+export function CancelOrderModal({ onConfirm, onClose, isCancelling }: CancelOrderModalProps) {
+    return (
+        <div
+            className="fixed inset-0 bg-black/75 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+            onClick={() => { if (!isCancelling) onClose(); }}
+        >
+            <style>
+                {`
+                @keyframes slideUpCenter {
+                    0% { transform: translateY(50px); opacity: 0; }
+                    100% { transform: translateY(0); opacity: 1; }
+                }
+                .animate-slideUpCenter {
+                    animation: slideUpCenter 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+                }
+                `}
+            </style>
+
+            <div
+                className="bg-[#0E0E13] border border-[#454932]/20 shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] rounded-lg w-full max-w-[480px] flex flex-col overflow-hidden animate-slideUpCenter"
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="flex flex-col items-center p-8 gap-6">
+                    <div className="w-16 h-16 rounded-full bg-[#FF6B6B]/10 border border-[#FF6B6B]/20 flex items-center justify-center">
+                        <svg viewBox="0 0 24 24" className="w-8 h-8 text-[#FF6B6B]" fill="none" stroke="currentColor" strokeWidth="2">
+                            <path d="M18 6L6 18M6 6l12 12" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                    </div>
+
+                    <div className="text-center space-y-2">
+                        <h3 className="text-[#E4E1E9] font-bold text-2xl font-space">
+                            Cancel this order?
+                        </h3>
+                        <p className="text-[#8F8389] text-sm font-space leading-relaxed max-w-[360px]">
+                            This action will stop the current trade. You can only cancel while payment has not been marked as completed.
+                        </p>
+                    </div>
+
+                    <div className="w-full flex flex-col gap-3 pt-2">
+                        <button
+                            type="button"
+                            onClick={onConfirm}
+                            disabled={isCancelling}
+                            className="w-full bg-[#FF6B6B] hover:bg-[#ff5252] text-[#1B0505] font-bold text-lg py-4 rounded-lg shadow-[0_0_30px_rgba(255,107,107,0.15)] transition-all duration-200 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 font-space"
+                        >
+                            {isCancelling ? (
+                                <>
+                                    <Loader2 className="w-5 h-5 animate-spin" />
+                                    Cancelling...
+                                </>
+                            ) : (
+                                "Cancel Order"
+                            )}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            disabled={isCancelling}
+                            className="w-full bg-[#2A292F] hover:bg-[#35343b] text-[#E4E1E9] font-bold text-base py-3.5 rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed font-space"
+                        >
+                            Keep Order
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/(protected)/p2p/orders/components/EvidencePreview.tsx
+++ b/src/app/(protected)/p2p/orders/components/EvidencePreview.tsx
@@ -18,6 +18,9 @@ export interface EvidencePreviewProps {
     expiresAt?: string;
     evidenceUrl?: string | null;
     onStatusChange: () => void;
+    canCancel: boolean;
+    isCancelling: boolean;
+    onCancelOrder: () => void;
 }
 
 export function EvidencePreview({
@@ -28,7 +31,10 @@ export function EvidencePreview({
     amount,
     expiresAt,
     evidenceUrl,
-    onStatusChange
+    onStatusChange,
+    canCancel,
+    isCancelling,
+    onCancelOrder
 }: EvidencePreviewProps) {
     const { fundEscrow, releaseEscrow, syncEscrow } = useEscrows();
     const { updateOrder } = useOrders();
@@ -117,9 +123,8 @@ export function EvidencePreview({
     };
 
     const handleCancel = () => {
-        if (confirm("Are you sure you want to cancel this P2P operation?")) {
-            alert("Operation cancelled.");
-        }
+        if (!canCancel || isCancelling) return;
+        onCancelOrder();
     };
 
     const handleSignatureRetry = async () => {
@@ -333,9 +338,10 @@ export function EvidencePreview({
                     <button 
                         type="button" 
                         onClick={handleCancel}
-                        className="bg-transparent hover:bg-white/[0.02] w-full h-[58px] text-[#C2C7D0] border border-[rgba(69,73,50,0.3)] font-bold text-[16px] leading-[24px] rounded-[12px] uppercase transition-all duration-200 tracking-[-0.4px]"
+                        disabled={!canCancel || isCancelling}
+                        className="bg-transparent hover:bg-[#FF6B6B]/5 hover:border-[#FF6B6B]/50 hover:text-[#FF6B6B] disabled:hover:bg-transparent disabled:hover:border-[rgba(69,73,50,0.3)] disabled:hover:text-[#C2C7D0] w-full h-[58px] text-[#C2C7D0] border border-[rgba(69,73,50,0.3)] font-bold text-[16px] leading-[24px] rounded-[12px] uppercase transition-all duration-200 tracking-[-0.4px] cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                     >
-                        CANCEL OPERATION
+                        {isCancelling ? "CANCELLING..." : "CANCEL OPERATION"}
                     </button>
                 )}
             </div>

--- a/src/app/(protected)/p2p/orders/components/TradeEvidenceUploader.tsx
+++ b/src/app/(protected)/p2p/orders/components/TradeEvidenceUploader.tsx
@@ -16,6 +16,9 @@ export interface TradeEvidenceUploaderProps {
     amount: number;
     evidenceUrl?: string | null;
     onStatusChange: () => void;
+    canCancel: boolean;
+    isCancelling: boolean;
+    onCancelOrder: () => void;
 }
 
 export function TradeEvidenceUploader({
@@ -23,7 +26,10 @@ export function TradeEvidenceUploader({
     escrowStatus,
     buyerAddress,
     evidenceUrl,
-    onStatusChange
+    onStatusChange,
+    canCancel,
+    isCancelling,
+    onCancelOrder
 }: TradeEvidenceUploaderProps) {
     const { markFiatSent, syncEscrow, uploadEvidence } = useEscrows();
 
@@ -187,9 +193,8 @@ export function TradeEvidenceUploader({
     };
 
     const handleCancel = () => {
-        if (confirm("Are you sure you want to cancel this P2P operation?")) {
-            alert("Operation cancelled.");
-        }
+        if (!canCancel || isCancelling) return;
+        onCancelOrder();
     };
 
     const handleSignatureRetry = async () => {
@@ -446,9 +451,10 @@ export function TradeEvidenceUploader({
                     <button 
                         type="button" 
                         onClick={handleCancel}
-                        className="bg-transparent hover:bg-white/[0.02] w-full h-[58px] text-[#C2C7D0] border border-[rgba(69,73,50,0.3)] font-bold text-[16px] leading-[24px] rounded-[12px] uppercase transition-all duration-200 tracking-[-0.4px] cursor-pointer"
+                        disabled={!canCancel || isCancelling}
+                        className="bg-transparent hover:bg-[#FF6B6B]/5 hover:border-[#FF6B6B]/50 hover:text-[#FF6B6B] disabled:hover:bg-transparent disabled:hover:border-[rgba(69,73,50,0.3)] disabled:hover:text-[#C2C7D0] w-full h-[58px] text-[#C2C7D0] border border-[rgba(69,73,50,0.3)] font-bold text-[16px] leading-[24px] rounded-[12px] uppercase transition-all duration-200 tracking-[-0.4px] cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                     >
-                        CANCEL OPERATION
+                        {isCancelling ? "CANCELLING..." : "CANCEL OPERATION"}
                     </button>
                 )}
             </div>

--- a/src/app/(protected)/p2p/orders/components/__tests__/CancelOrderModal.test.tsx
+++ b/src/app/(protected)/p2p/orders/components/__tests__/CancelOrderModal.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CancelOrderModal } from "../CancelOrderModal";
+
+describe("CancelOrderModal", () => {
+    it("renders the confirmation copy and both actions", () => {
+        render(
+            <CancelOrderModal onConfirm={vi.fn()} onClose={vi.fn()} isCancelling={false} />,
+        );
+
+        expect(screen.getByText("Cancel this order?")).toBeTruthy();
+        expect(screen.getByRole("button", { name: /cancel order/i })).toBeTruthy();
+        expect(screen.getByRole("button", { name: /keep order/i })).toBeTruthy();
+    });
+
+    it("calls onConfirm when the Cancel Order button is clicked", () => {
+        const onConfirm = vi.fn();
+        render(
+            <CancelOrderModal onConfirm={onConfirm} onClose={vi.fn()} isCancelling={false} />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: /cancel order/i }));
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when the Keep Order button is clicked", () => {
+        const onClose = vi.fn();
+        render(
+            <CancelOrderModal onConfirm={vi.fn()} onClose={onClose} isCancelling={false} />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: /keep order/i }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when the backdrop is clicked", () => {
+        const onClose = vi.fn();
+        const { container } = render(
+            <CancelOrderModal onConfirm={vi.fn()} onClose={onClose} isCancelling={false} />,
+        );
+
+        fireEvent.click(container.firstChild as Element);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables both actions and shows a loading label while cancelling", () => {
+        render(
+            <CancelOrderModal onConfirm={vi.fn()} onClose={vi.fn()} isCancelling={true} />,
+        );
+
+        expect(screen.getByText("Cancelling...")).toBeTruthy();
+        const confirmButton = screen.getByRole("button", { name: /cancelling/i }) as HTMLButtonElement;
+        const keepButton = screen.getByRole("button", { name: /keep order/i }) as HTMLButtonElement;
+        expect(confirmButton.disabled).toBe(true);
+        expect(keepButton.disabled).toBe(true);
+    });
+
+    it("does not close on backdrop click while cancelling", () => {
+        const onClose = vi.fn();
+        const { container } = render(
+            <CancelOrderModal onConfirm={vi.fn()} onClose={onClose} isCancelling={true} />,
+        );
+
+        fireEvent.click(container.firstChild as Element);
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("does not call onClose when clicking inside the modal content", () => {
+        const onClose = vi.fn();
+        render(
+            <CancelOrderModal onConfirm={vi.fn()} onClose={onClose} isCancelling={false} />,
+        );
+
+        fireEvent.click(screen.getByText("Cancel this order?"));
+        expect(onClose).not.toHaveBeenCalled();
+    });
+});

--- a/src/features/order/hooks/__tests__/useOrders.test.ts
+++ b/src/features/order/hooks/__tests__/useOrders.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useOrders, ApiError } from "../useOrders";
+import * as UserContextModule from "../../../user/presentation/context/UserContext";
+
+vi.mock("../../../user/presentation/context/UserContext", () => ({
+    useUser: vi.fn(),
+}));
+
+const mockedUseUser = vi.mocked(UserContextModule.useUser);
+
+function mockFetchResponse(status: number, body: unknown) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+    } as Response;
+}
+
+describe("useOrders", () => {
+    const logout = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockedUseUser.mockReturnValue({
+            accessToken: "test-token",
+            logout,
+        } as unknown as ReturnType<typeof UserContextModule.useUser>);
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    describe("cancelOrder", () => {
+        it("calls POST /orders/:id/cancel with the auth header and returns the updated order", async () => {
+            const updatedOrder = { orderId: "order-1", orderStatus: "cancelled" };
+            (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+                mockFetchResponse(200, updatedOrder),
+            );
+
+            const { result } = renderHook(() => useOrders());
+
+            let response: unknown;
+            await act(async () => {
+                response = await result.current.cancelOrder("order-1");
+            });
+
+            expect(fetch).toHaveBeenCalledWith(
+                expect.stringContaining("/orders/order-1/cancel"),
+                expect.objectContaining({
+                    method: "POST",
+                    headers: expect.objectContaining({
+                        Authorization: "Bearer test-token",
+                    }),
+                }),
+            );
+            expect(response).toEqual(updatedOrder);
+            expect(result.current.order).toEqual(updatedOrder);
+        });
+
+        it("throws an ApiError carrying the HTTP status and backend error code on 409", async () => {
+            (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+                mockFetchResponse(409, {
+                    statusCode: 409,
+                    error: "ORDER_CANCELLATION_NOT_ALLOWED",
+                    message: 'Order order-1 cannot be cancelled because it is already "released"',
+                }),
+            );
+
+            const { result } = renderHook(() => useOrders());
+
+            let caught: unknown;
+            await act(async () => {
+                try {
+                    await result.current.cancelOrder("order-1");
+                } catch (err) {
+                    caught = err;
+                }
+            });
+
+            expect(caught).toBeInstanceOf(ApiError);
+            expect((caught as ApiError).status).toBe(409);
+            expect((caught as ApiError).code).toBe("ORDER_CANCELLATION_NOT_ALLOWED");
+        });
+
+        it("throws an ApiError with status 403 when the user is not a participant", async () => {
+            (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+                mockFetchResponse(403, {
+                    statusCode: 403,
+                    error: "UNAUTHORIZED_ACTION",
+                    message: "Only the buyer or seller on this order can cancel it",
+                }),
+            );
+
+            const { result } = renderHook(() => useOrders());
+
+            let caught: unknown;
+            await act(async () => {
+                try {
+                    await result.current.cancelOrder("order-1");
+                } catch (err) {
+                    caught = err;
+                }
+            });
+
+            expect(caught).toBeInstanceOf(ApiError);
+            expect((caught as ApiError).status).toBe(403);
+            expect((caught as ApiError).code).toBe("UNAUTHORIZED_ACTION");
+        });
+
+        it("logs the user out and throws on a 401", async () => {
+            (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+                mockFetchResponse(401, {}),
+            );
+
+            const { result } = renderHook(() => useOrders());
+
+            await act(async () => {
+                await expect(result.current.cancelOrder("order-1")).rejects.toThrow();
+            });
+
+            expect(logout).toHaveBeenCalledTimes(1);
+        });
+
+        it("omits the Authorization header when there is no access token", async () => {
+            mockedUseUser.mockReturnValue({
+                accessToken: null,
+                logout,
+            } as unknown as ReturnType<typeof UserContextModule.useUser>);
+            (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+                mockFetchResponse(200, { orderId: "order-1", orderStatus: "cancelled" }),
+            );
+
+            const { result } = renderHook(() => useOrders());
+
+            await act(async () => {
+                await result.current.cancelOrder("order-1");
+            });
+
+            const [, options] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+            expect((options.headers as Record<string, string>).Authorization).toBeUndefined();
+        });
+    });
+});

--- a/src/features/order/hooks/useOrders.ts
+++ b/src/features/order/hooks/useOrders.ts
@@ -4,6 +4,24 @@ import { CreateOrder } from "../models/createOrder";
 import { UpdateOrder } from "../models/updateOrder";
 import { useUser } from "../../user/presentation/context/UserContext";
 
+/**
+ * Backend errors are shaped as { statusCode, error, message } (see
+ * AppException in ikash-backend). This preserves that shape on the client
+ * so callers can branch on `err.code` (e.g. "ORDER_CANCELLATION_NOT_ALLOWED")
+ * instead of parsing message text.
+ */
+export class ApiError extends Error {
+    status: number;
+    code?: string;
+
+    constructor(message: string, status: number, code?: string) {
+        super(message);
+        this.name = "ApiError";
+        this.status = status;
+        this.code = code;
+    }
+}
+
 export function useOrders() {
     const [orders, setOrders] = useState<Order[]>([]);
     const [order, setOrder] = useState<Order | null>(null);
@@ -17,7 +35,7 @@ export function useOrders() {
         if (!res.ok) {
             const errData = await res.json().catch(() => ({}));
             const msg = errData.message ? (Array.isArray(errData.message) ? errData.message.join(', ') : errData.message) : defaultError;
-            throw new Error(msg);
+            throw new ApiError(msg, res.status, errData.error);
         }
         return res.json();
     }, [logout]);
@@ -88,5 +106,23 @@ export function useOrders() {
         }
     };
 
-    return { orders, order, createOrder, getOrder, updateOrder, fetchUserOrders };
+    const cancelOrder = async (orderId: string) => {
+        try {
+            const headers: Record<string, string> = { "Content-type": "application/json" };
+            if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+
+            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/orders/${orderId}/cancel`, {
+                method: "POST",
+                headers,
+            });
+            const data = await handleResponse(res, 'Cancel order error');
+            setOrder(data);
+            return data;
+        } catch (error) {
+            console.error(error);
+            throw error;
+        }
+    };
+
+    return { orders, order, createOrder, getOrder, updateOrder, cancelOrder, fetchUserOrders };
 }

--- a/src/features/order/models/order.ts
+++ b/src/features/order/models/order.ts
@@ -5,7 +5,7 @@ export interface EscrowOnChain {
     escrowId: string;
     orderId: string;
     contractId?: string | null;
-    escrowStatus: "pending" | "initialized" | "funded" | "fiat_sent" | "released";
+    escrowStatus: "pending" | "initialized" | "funded" | "fiat_sent" | "released" | "disputed" | "resolved";
     amount?: number | string | null;
     buyerAddress?: string | null;
     sellerAddress?: string | null;

--- a/src/features/order/utils/__tests__/canCancelOrder.test.ts
+++ b/src/features/order/utils/__tests__/canCancelOrder.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { canCancelOrder } from "../canCancelOrder";
+import type { Order } from "../../models/order";
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+    return {
+        orderId: "order-1",
+        offerId: "offer-1",
+        buyerId: "buyer-1",
+        sellerId: "seller-1",
+        assetAmount: "10",
+        fiatAmount: "100",
+        orderStatus: "created",
+        expiresAt: null,
+        escrow: null,
+        ...overrides,
+    };
+}
+
+describe("canCancelOrder", () => {
+    it("allows cancellation for the buyer when there is no escrow yet", () => {
+        const order = makeOrder();
+        expect(canCancelOrder(order, "buyer-1")).toBe(true);
+    });
+
+    it("allows cancellation for the seller when there is no escrow yet", () => {
+        const order = makeOrder();
+        expect(canCancelOrder(order, "seller-1")).toBe(true);
+    });
+
+    it("denies cancellation for an unrelated user", () => {
+        const order = makeOrder();
+        expect(canCancelOrder(order, "stranger-1")).toBe(false);
+    });
+
+    it.each(["released", "cancelled", "expired", "disputed"] as const)(
+        "denies cancellation when order status is already '%s'",
+        (orderStatus) => {
+            const order = makeOrder({ orderStatus });
+            expect(canCancelOrder(order, "buyer-1")).toBe(false);
+        },
+    );
+
+    it.each(["pending", "initialized"] as const)(
+        "allows cancellation when escrow status is '%s'",
+        (escrowStatus) => {
+            const order = makeOrder({
+                escrow: {
+                    escrowId: "escrow-1",
+                    orderId: "order-1",
+                    escrowStatus,
+                },
+            });
+            expect(canCancelOrder(order, "buyer-1")).toBe(true);
+        },
+    );
+
+    it.each(["funded", "fiat_sent", "released", "disputed", "resolved"] as const)(
+        "denies cancellation when escrow status is '%s'",
+        (escrowStatus) => {
+            const order = makeOrder({
+                escrow: {
+                    escrowId: "escrow-1",
+                    orderId: "order-1",
+                    escrowStatus,
+                },
+            });
+            expect(canCancelOrder(order, "buyer-1")).toBe(false);
+        },
+    );
+});

--- a/src/features/order/utils/canCancelOrder.ts
+++ b/src/features/order/utils/canCancelOrder.ts
@@ -1,0 +1,32 @@
+import { Order } from "../models/order";
+
+/**
+ * Mirrors the backend eligibility rules in OrderService.cancel()
+ * (ikash-backend, src/modules/order/order.service.ts). Keep this in sync
+ * with the backend — it exists purely to hide the Cancel Order action when
+ * the request would be rejected, not as a source of truth. The backend is
+ * always the final authority; this just avoids showing a button that will
+ * 409.
+ */
+const TERMINAL_ORDER_STATUSES = ["released", "cancelled", "expired", "disputed"];
+
+const BLOCKED_ESCROW_STATUSES = [
+    "funded",
+    "fiat_sent",
+    "released",
+    "disputed",
+    "resolved",
+];
+
+export function canCancelOrder(order: Order, currentUserId: string): boolean {
+    const isParticipant = order.buyerId === currentUserId || order.sellerId === currentUserId;
+    if (!isParticipant) return false;
+
+    if (TERMINAL_ORDER_STATUSES.includes(order.orderStatus)) return false;
+
+    if (order.escrow && BLOCKED_ESCROW_STATUSES.includes(order.escrow.escrowStatus)) {
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Pull Request Summary
### Related Issue
Closes #67

### Description
Adds a Cancel Order action to the order details page, allowing an eligible
buyer or seller to cancel a P2P order before fiat payment has been marked
as completed. Previously there was no way to exit an order from the UI
before payment.

This implementation is built against the actual backend contract from
ikash-backend#42 (`POST /orders/:id/cancel`) rather than the original
issue's guessed status names, since that PR was already drafted and its
real enums/error shapes were available to build against.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] UI/UX improvement
- [ ] Backend/API change
- [ ] Database/Prisma change
- [ ] Refactor
- [ ] Documentation update
- [ ] Configuration/deployment change
- [x] Test update

---
## Changes Made
- Added a "Cancel Order" button to the order details page subheader, visible only to the order's buyer/seller and only while the order is in a cancellable state.
- Added `canCancelOrder()` util mirroring the backend's exact eligibility rules (participant check, terminal order statuses, blocked escrow statuses), so the button only appears when the request would actually succeed.
- Added `useOrders().cancelOrder()` calling `POST /orders/:id/cancel`.
- Added `ApiError` class preserving the backend's `{statusCode, error, message}` error shape, so the UI can detect a `409` conflict specifically instead of parsing message text.
- Added `CancelOrderModal` confirmation modal, matching the existing `SignatureCancelledModal` visual pattern.
- Fixed `EscrowOnChain.escrowStatus` type — was missing `'disputed'` and `'resolved'`, 2 of the real backend enum's 7 values.
- Added `canCancelOrder.test.ts` (14 test cases).

---
## Screenshots / Videos
<!-- Paste after screenshot here -->

---
## Testing
### How was this tested?
- [x] Tested locally
- [ ] Tested on mobile screen size
- [ ] Tested on desktop screen size
- [x] Tested with wallet connected
- [ ] Tested without wallet connected
- [ ] Tested API manually
- [x] Added or updated automated tests

### Test details
1. `pnpm vitest run` — 3 suites, 42 tests pass, including 14 new `canCancelOrder` cases covering eligible/ineligible order and escrow states.
2. `pnpm exec tsc --noEmit` — clean on all changed/new files.



---
## Frontend Checklist
- [x] UI matches the expected design or issue requirements
- [ ] Responsive behavior was verified
- [x] Loading states are handled
- [x] Empty states are handled
- [x] Error states are handled
- [x] No console errors were introduced
- [x] Existing user flow was not broken

---
## Backend Checklist
- [x] Not applicable (frontend-only PR; backend change is ikash-backend#42)

---
## Database / Prisma Changes
Does this PR include database or Prisma changes?
- [ ] Yes
- [x] No

---
## Environment Variables
Does this PR require new or updated environment variables?
- [ ] Yes
- [x] No

---
## Risk / open item
This PR depends on ikash-backend#42, which has not been merged yet. If
review changes that PR's status enums, error shape, or guard behavior,
this frontend will need a follow-up adjustment to match.

## Optional Ikash Traction Support
- [x] I joined the waitlist
- [x] I connected a wallet
- [ ] I have not done it yet
- [ ] I prefer not to do it


