### PR TITLE
[IKSH-22] Implement Active Orders Dashboard UI Using Temporary Mock Data

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { Aside } from "../../components/Aside";
 import { Header } from "../../components/Header";
 import { WalletDashboard } from "./components/WalletDashboard";
+import { ActiveOrdersSection } from "@/features/order/components/ActiveOrdersSection";
 import { useUser } from "@/features/user/presentation/context/UserContext";
 import { Suspense } from "react";
 
@@ -28,7 +29,16 @@ export default function DashboardPage() {
                     }>
                         <WalletDashboard />
                     </Suspense>
+                    {/* Active Orders — right panel (desktop) */}
+                    <div className="hidden md:flex flex-col flex-1 min-w-0 pt-12 pr-8 pl-10">
+                        <ActiveOrdersSection />
+                    </div>
                 </main>
+
+                {/* Active Orders — mobile (below wallet) */}
+                <div className="md:hidden px-4 pb-24">
+                    <ActiveOrdersSection />
+                </div>
             </div>
         </div>
     );

--- a/src/features/order/components/ActiveOrderCard.tsx
+++ b/src/features/order/components/ActiveOrderCard.tsx
@@ -90,9 +90,11 @@ export function ActiveOrderCard({ order }: ActiveOrderCardProps) {
                 <div className="flex items-center gap-3">
                     <div className="w-9 h-9 rounded-full bg-[#2a2a2a] border border-[#3a3a3a] shrink-0 overflow-hidden">
                         {order.counterpartyProfileImageUrl ? (
-                            <img
+                            <Image
                                 src={order.counterpartyProfileImageUrl}
-                                alt=""
+                                alt={order.counterpartyName || "Counterparty profile image"}
+                                width={36}
+                                height={36}
                                 className="w-full h-full object-cover"
                             />
                         ) : null}

--- a/src/features/order/components/ActiveOrderCard.tsx
+++ b/src/features/order/components/ActiveOrderCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Image from "next/image";
+import { Landmark } from "lucide-react";
 import { ActiveOrderMock } from "../mocks/active-orders.mock";
 
 function getRelativeTime(date: Date): string {
@@ -17,38 +19,17 @@ interface ActiveOrderCardProps {
     order: ActiveOrderMock;
 }
 
-function UsdcIcon() {
-    return (
-        <div className="w-7 h-7 rounded-full bg-[#2775CA] flex items-center justify-center shrink-0 border-2 border-[#3a8fe8]">
-            <svg width="14" height="14" viewBox="0 0 32 32" fill="none">
-                <circle cx="16" cy="16" r="16" fill="#2775CA" />
-                <path
-                    d="M20.022 18.124c0-2.124-1.28-2.854-3.84-3.153-1.828-.232-2.194-.696-2.194-1.508s.597-1.324 1.793-1.324c1.08 0 1.677.36 1.976 1.24.066.232.232.348.464.348h1.061a.425.425 0 00.43-.43v-.066a3.17 3.17 0 00-2.84-2.59V9.69a.476.476 0 00-.48-.48h-1.01a.476.476 0 00-.48.48v.895c-1.61.232-2.656 1.34-2.656 2.754 0 2.025 1.245 2.787 3.806 3.087 1.694.232 2.228.63 2.228 1.54 0 .91-.795 1.541-1.876 1.541-1.478 0-1.976-.629-2.128-1.508-.066-.265-.232-.397-.464-.397h-1.11a.425.425 0 00-.43.43v.066c.33 1.694 1.345 2.887 3.557 3.22v.928c0 .265.215.48.48.48h1.01c.265 0 .48-.215.48-.48v-.911c1.66-.298 2.722-1.44 2.722-2.971z"
-                    fill="white"
-                />
-            </svg>
-        </div>
-    );
-}
-
-function BankIcon() {
-    return (
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" className="text-[#8F8389]">
-            <path d="M3 21h18M3 10h18M5 6l7-3 7 3M4 10v11M8 10v11M12 10v11M16 10v11M20 10v11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-    );
-}
+// Status pill: border colored, text white (per reviewer feedback)
+const STATUS_BORDER: Record<string, string> = {
+    FUNDING:     "border-[#BCED09]",
+    PENDING:     "border-yellow-400",
+    IN_PROGRESS: "border-blue-400",
+    // COMPLETED intentionally omitted — completed orders do not appear in the active section
+};
 
 export function ActiveOrderCard({ order }: ActiveOrderCardProps) {
     const displayTime = getRelativeTime(order.updatedAt);
-
-    const statusColors: Record<string, string> = {
-        FUNDING: "border-[#BCED09] text-[#BCED09]",
-        PENDING: "border-yellow-400 text-yellow-400",
-        IN_PROGRESS: "border-blue-400 text-blue-400",
-        COMPLETED: "border-green-400 text-green-400",
-    };
-    const statusClass = statusColors[order.status] ?? "border-[#8F8389] text-[#8F8389]";
+    const statusBorder = STATUS_BORDER[order.status] ?? "border-[#8F8389]";
 
     return (
         <div
@@ -56,48 +37,66 @@ export function ActiveOrderCard({ order }: ActiveOrderCardProps) {
                        min-w-[260px] w-full transition-all duration-200 hover:border-[#2a2a2a] hover:bg-[#151517]"
             data-testid="active-order-card"
         >
-            {/* Top section */}
+            {/* Top section — 24px gap and padding per Figma */}
             <div className="flex flex-col gap-6 p-6">
                 {/* Role + Status row */}
                 <div className="flex items-center justify-between">
                     <span className="text-[11px] font-semibold tracking-[0.15em] text-[#8F8389] uppercase">
                         {order.role}
                     </span>
+                    {/* Border colored, text white */}
                     <span
-                        className={`text-[11px] font-bold tracking-[0.12em] uppercase px-3 py-1 rounded-full border ${statusClass}`}
+                        className={`text-[11px] font-bold tracking-[0.12em] uppercase px-3 py-1 rounded-full border text-white ${statusBorder}`}
                     >
                         {order.status}
                     </span>
                 </div>
 
-                {/* Amount + Asset row */}
-                <div className="flex items-center jusitfy-between">
+                {/* Amount + Asset row — asset icon aligned to the right */}
+                <div className="flex items-center justify-between">
                     <span className="text-[32px] font-bold text-white tracking-tight leading-none">
                         {order.assetAmount}
                     </span>
                     <div className="flex items-center gap-2">
-                        <UsdcIcon />
+                        {/* USDC icon loaded from public assets */}
+                        <div className="w-7 h-7 rounded-full overflow-hidden shrink-0">
+                            <Image
+                                src="/usdc.png"
+                                alt="USDC"
+                                width={28}
+                                height={28}
+                                className="w-full h-full object-cover"
+                            />
+                        </div>
                         <span className="text-[13px] font-semibold text-[#c0c0c0] tracking-wider">
                             {order.assetCode}
                         </span>
                     </div>
                 </div>
 
-                {/* Payment method */}
+                {/* Payment method — Landmark icon from lucide-react */}
                 <div className="flex items-center gap-2">
-                    <BankIcon />
+                    <Landmark size={16} className="text-[#8F8389] shrink-0" />
                     <span className="text-[13px] text-[#8F8389]">{order.paymentMethod}</span>
                 </div>
             </div>
 
             {/* Divider */}
-            <div className="h-px bg-[#1f1f1f] mx-5" />
+            <div className="h-px bg-[#1f1f1f] mx-6" />
 
-            {/* Bottom section */}
-            <div className="flex flex-col gap-4 p-5">
-                {/* Counterparty */}
+            {/* Bottom section — 24px gap and padding per Figma */}
+            <div className="flex flex-col gap-6 p-6">
+                {/* Counterparty — profile image pattern from P2P panel */}
                 <div className="flex items-center gap-3">
-                    <div className="w-9 h-9 rounded-full bg-[#2a2a2a] border border-[#3a3a3a] shrink-0" />
+                    <div className="w-9 h-9 rounded-full bg-[#2a2a2a] border border-[#3a3a3a] shrink-0 overflow-hidden">
+                        {order.counterpartyProfileImageUrl ? (
+                            <img
+                                src={order.counterpartyProfileImageUrl}
+                                alt=""
+                                className="w-full h-full object-cover"
+                            />
+                        ) : null}
+                    </div>
                     <div>
                         <p className="text-[13px] font-semibold text-white leading-tight">
                             {order.counterpartyName}
@@ -111,8 +110,8 @@ export function ActiveOrderCard({ order }: ActiveOrderCardProps) {
                     </div>
                 </div>
 
-                {/* Time + Open button */}
-                <div className="flex items-center justify-between">
+                {/* Time + Open button — items aligned at bottom */}
+                <div className="flex items-end justify-between">
                     <span className="text-[12px] text-[#8F8389]">{displayTime}</span>
                     {/* Open button — disabled for mock orders to prevent invalid navigation */}
                     <button

--- a/src/features/order/components/ActiveOrderCard.tsx
+++ b/src/features/order/components/ActiveOrderCard.tsx
@@ -71,7 +71,7 @@ export function ActiveOrderCard({ order }: ActiveOrderCardProps) {
                 </div>
 
                 {/* Amount + Asset row */}
-                <div className="flex items-center gap-3">
+                <div className="flex items-center jusitfy-between">
                     <span className="text-[32px] font-bold text-white tracking-tight leading-none">
                         {order.assetAmount}
                     </span>

--- a/src/features/order/components/ActiveOrderCard.tsx
+++ b/src/features/order/components/ActiveOrderCard.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { ActiveOrderMock } from "../mocks/active-orders.mock";
+
+function getRelativeTime(date: Date): string {
+    const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+    if (seconds < 60) return "just now";
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes} min${minutes !== 1 ? "s" : ""} ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours} hour${hours !== 1 ? "s" : ""} ago`;
+    const days = Math.floor(hours / 24);
+    return `${days} day${days !== 1 ? "s" : ""} ago`;
+}
+
+interface ActiveOrderCardProps {
+    order: ActiveOrderMock;
+}
+
+function UsdcIcon() {
+    return (
+        <div className="w-7 h-7 rounded-full bg-[#2775CA] flex items-center justify-center shrink-0 border-2 border-[#3a8fe8]">
+            <svg width="14" height="14" viewBox="0 0 32 32" fill="none">
+                <circle cx="16" cy="16" r="16" fill="#2775CA" />
+                <path
+                    d="M20.022 18.124c0-2.124-1.28-2.854-3.84-3.153-1.828-.232-2.194-.696-2.194-1.508s.597-1.324 1.793-1.324c1.08 0 1.677.36 1.976 1.24.066.232.232.348.464.348h1.061a.425.425 0 00.43-.43v-.066a3.17 3.17 0 00-2.84-2.59V9.69a.476.476 0 00-.48-.48h-1.01a.476.476 0 00-.48.48v.895c-1.61.232-2.656 1.34-2.656 2.754 0 2.025 1.245 2.787 3.806 3.087 1.694.232 2.228.63 2.228 1.54 0 .91-.795 1.541-1.876 1.541-1.478 0-1.976-.629-2.128-1.508-.066-.265-.232-.397-.464-.397h-1.11a.425.425 0 00-.43.43v.066c.33 1.694 1.345 2.887 3.557 3.22v.928c0 .265.215.48.48.48h1.01c.265 0 .48-.215.48-.48v-.911c1.66-.298 2.722-1.44 2.722-2.971z"
+                    fill="white"
+                />
+            </svg>
+        </div>
+    );
+}
+
+function BankIcon() {
+    return (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" className="text-[#8F8389]">
+            <path d="M3 21h18M3 10h18M5 6l7-3 7 3M4 10v11M8 10v11M12 10v11M16 10v11M20 10v11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+    );
+}
+
+export function ActiveOrderCard({ order }: ActiveOrderCardProps) {
+    const displayTime = getRelativeTime(order.updatedAt);
+
+    const statusColors: Record<string, string> = {
+        FUNDING: "border-[#BCED09] text-[#BCED09]",
+        PENDING: "border-yellow-400 text-yellow-400",
+        IN_PROGRESS: "border-blue-400 text-blue-400",
+        COMPLETED: "border-green-400 text-green-400",
+    };
+    const statusClass = statusColors[order.status] ?? "border-[#8F8389] text-[#8F8389]";
+
+    return (
+        <div
+            className="flex flex-col rounded-2xl bg-[#121214] border border-[#1f1f1f] overflow-hidden
+                       min-w-[260px] w-full transition-all duration-200 hover:border-[#2a2a2a] hover:bg-[#151517]"
+            data-testid="active-order-card"
+        >
+            {/* Top section */}
+            <div className="flex flex-col gap-4 p-5">
+                {/* Role + Status row */}
+                <div className="flex items-center justify-between">
+                    <span className="text-[11px] font-semibold tracking-[0.15em] text-[#8F8389] uppercase">
+                        {order.role}
+                    </span>
+                    <span
+                        className={`text-[11px] font-bold tracking-[0.12em] uppercase px-3 py-1 rounded-full border ${statusClass}`}
+                    >
+                        {order.status}
+                    </span>
+                </div>
+
+                {/* Amount + Asset row */}
+                <div className="flex items-center gap-3">
+                    <span className="text-[32px] font-bold text-white tracking-tight leading-none">
+                        {order.assetAmount}
+                    </span>
+                    <div className="flex items-center gap-2">
+                        <UsdcIcon />
+                        <span className="text-[13px] font-semibold text-[#c0c0c0] tracking-wider">
+                            {order.assetCode}
+                        </span>
+                    </div>
+                </div>
+
+                {/* Payment method */}
+                <div className="flex items-center gap-2">
+                    <BankIcon />
+                    <span className="text-[13px] text-[#8F8389]">{order.paymentMethod}</span>
+                </div>
+            </div>
+
+            {/* Divider */}
+            <div className="h-px bg-[#1f1f1f] mx-5" />
+
+            {/* Bottom section */}
+            <div className="flex flex-col gap-4 p-5">
+                {/* Counterparty */}
+                <div className="flex items-center gap-3">
+                    <div className="w-9 h-9 rounded-full bg-[#2a2a2a] border border-[#3a3a3a] shrink-0" />
+                    <div>
+                        <p className="text-[13px] font-semibold text-white leading-tight">
+                            {order.counterpartyName}
+                        </p>
+                        <p className="text-[11px] text-[#8F8389] leading-tight">
+                            Unit price&nbsp;
+                            <span className="font-bold text-[#c0c0c0]">
+                                {order.unitPrice} {order.fiatCurrency}
+                            </span>
+                        </p>
+                    </div>
+                </div>
+
+                {/* Time + Open button */}
+                <div className="flex items-center justify-between">
+                    <span className="text-[12px] text-[#8F8389]">{displayTime}</span>
+                    {/* Open button — disabled for mock orders to prevent invalid navigation */}
+                    <button
+                        disabled
+                        title="Available once backend integration is enabled"
+                        className="px-5 py-2 rounded-full bg-[#BCED09] text-black text-[13px] font-bold
+                                   tracking-wide cursor-not-allowed opacity-90 transition-all duration-150
+                                   hover:opacity-100"
+                    >
+                        Open
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/features/order/components/ActiveOrderCard.tsx
+++ b/src/features/order/components/ActiveOrderCard.tsx
@@ -57,7 +57,7 @@ export function ActiveOrderCard({ order }: ActiveOrderCardProps) {
             data-testid="active-order-card"
         >
             {/* Top section */}
-            <div className="flex flex-col gap-4 p-5">
+            <div className="flex flex-col gap-6 p-6">
                 {/* Role + Status row */}
                 <div className="flex items-center justify-between">
                     <span className="text-[11px] font-semibold tracking-[0.15em] text-[#8F8389] uppercase">

--- a/src/features/order/components/ActiveOrdersSection.tsx
+++ b/src/features/order/components/ActiveOrdersSection.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+// TODO: Restore backend active-orders integration after the dashboard UI is approved.
+// import { useOrders } from "../hooks/useOrders";
+// import { useUser } from "@/features/user/presentation/context/UserContext";
+
+// TODO: Replace mockActiveOrders with backend active-order data
+// once the new dashboard design is validated.
+import { mockActiveOrders } from "../mocks/active-orders.mock";
+import { ActiveOrderCard } from "./ActiveOrderCard";
+
+export function ActiveOrdersSection() {
+    // TODO: Restore backend active-orders integration after the dashboard UI is approved.
+    // const { currentUser } = useUser();
+    // const { orders, fetchUserOrders } = useOrders();
+    //
+    // useEffect(() => {
+    //     if (currentUser?.userId) {
+    //         fetchUserOrders(currentUser.userId);
+    //     }
+    // }, [currentUser?.userId, fetchUserOrders]);
+    //
+    // const activeOrders = orders.filter(
+    //     (o) => o.orderStatus !== "cancelled" && o.orderStatus !== "completed"
+    // );
+
+    const activeOrders = mockActiveOrders;
+
+    if (activeOrders.length === 0) return null;
+
+    return (
+        <section className="w-full">
+            <div className="flex items-center justify-between mb-5 px-1">
+                <h2 className="text-white font-bold text-base tracking-wide">
+                    Active Orders
+                </h2>
+            </div>
+
+            {/* Desktop: 3-column grid | Mobile: horizontal scroll */}
+            <div
+                className="
+                    flex gap-4
+                    overflow-x-auto pb-2
+                    sm:overflow-x-visible sm:pb-0
+                    sm:grid sm:grid-cols-2
+                    lg:grid lg:grid-cols-3
+                "
+                style={{ scrollbarWidth: "none" }}
+            >
+                {activeOrders.map((order) => (
+                    <ActiveOrderCard key={order.id} order={order} />
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/features/order/components/__tests__/ActiveOrdersSection.test.tsx
+++ b/src/features/order/components/__tests__/ActiveOrdersSection.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ActiveOrdersSection } from "../ActiveOrdersSection";
+import { mockActiveOrders } from "../../mocks/active-orders.mock";
+
+// Mock the ActiveOrderCard to keep tests focused on the section
+vi.mock("../ActiveOrderCard", () => ({
+    ActiveOrderCard: ({ order }: { order: (typeof mockActiveOrders)[number] }) => (
+        <div data-testid="active-order-card" data-order-id={order.id}>
+            {order.counterpartyName}
+        </div>
+    ),
+}));
+
+describe("ActiveOrdersSection", () => {
+    it("renders exactly three mock order cards", () => {
+        render(<ActiveOrdersSection />);
+        const cards = screen.getAllByTestId("active-order-card");
+        expect(cards).toHaveLength(3);
+    });
+
+    it("renders the section heading", () => {
+        render(<ActiveOrdersSection />);
+        expect(screen.getByRole("heading", { name: /active orders/i })).toBeDefined();
+    });
+
+    it("renders cards with distinct ids from the mock data", () => {
+        render(<ActiveOrdersSection />);
+        const cards = screen.getAllByTestId("active-order-card");
+        const ids = cards.map((c) => c.getAttribute("data-order-id"));
+        expect(ids).toEqual(["mock-order-1", "mock-order-2", "mock-order-3"]);
+    });
+
+    it("mock data contains exactly three entries", () => {
+        expect(mockActiveOrders).toHaveLength(3);
+    });
+
+    it("each mock order has a unique id", () => {
+        const ids = mockActiveOrders.map((o) => o.id);
+        const unique = new Set(ids);
+        expect(unique.size).toBe(3);
+    });
+});

--- a/src/features/order/mocks/active-orders.mock.ts
+++ b/src/features/order/mocks/active-orders.mock.ts
@@ -1,0 +1,54 @@
+// TODO: Replace mockActiveOrders with backend active-order data
+// once the new dashboard design is validated.
+
+export interface ActiveOrderMock {
+    id: string;
+    role: 'BUYING' | 'SELLING';
+    status: string;
+    assetAmount: string;
+    assetCode: string;
+    paymentMethod: string;
+    counterpartyName: string;
+    unitPrice: string;
+    fiatCurrency: string;
+    updatedAt: Date;
+}
+
+export const mockActiveOrders: ActiveOrderMock[] = [
+    {
+        id: 'mock-order-1',
+        role: 'BUYING',
+        status: 'FUNDING',
+        assetAmount: '124.67',
+        assetCode: 'USDC',
+        paymentMethod: 'Visa transfer',
+        counterpartyName: 'Alex White',
+        unitPrice: '1.012',
+        fiatCurrency: 'USD',
+        updatedAt: new Date(),
+    },
+    {
+        id: 'mock-order-2',
+        role: 'BUYING',
+        status: 'FUNDING',
+        assetAmount: '124.67',
+        assetCode: 'USDC',
+        paymentMethod: 'Visa transfer',
+        counterpartyName: 'Alex White',
+        unitPrice: '1.012',
+        fiatCurrency: 'USD',
+        updatedAt: new Date(),
+    },
+    {
+        id: 'mock-order-3',
+        role: 'BUYING',
+        status: 'FUNDING',
+        assetAmount: '124.67',
+        assetCode: 'USDC',
+        paymentMethod: 'Visa transfer',
+        counterpartyName: 'Alex White',
+        unitPrice: '1.012',
+        fiatCurrency: 'USD',
+        updatedAt: new Date(),
+    },
+];

--- a/src/features/order/mocks/active-orders.mock.ts
+++ b/src/features/order/mocks/active-orders.mock.ts
@@ -9,6 +9,7 @@ export interface ActiveOrderMock {
     assetCode: string;
     paymentMethod: string;
     counterpartyName: string;
+    counterpartyProfileImageUrl?: string;
     unitPrice: string;
     fiatCurrency: string;
     updatedAt: Date;


### PR DESCRIPTION
## Pull Request Summary

### Related Issue
Closes #78

### Description
This PR implements the Active Orders dashboard section as specified in IKSH-22, using temporary mock data to match the approved Figma design while the UI is being validated.

- **Problem**: The dashboard had no Active Orders section, and the Figma design required one with a specific card layout.
- **What was implemented**: Three mock order cards are rendered in a dedicated `ActiveOrdersSection` component, each displaying role, status badge, asset amount, asset icon, payment method, counterparty info, unit price, relative time, and an Open button.
- **Why this approach**: Mock data is isolated in a separate file (`active-orders.mock.ts`) so it can be removed with a single import swap when the backend integration is re-enabled. The existing backend retrieval code (`useOrders` / `fetchUserOrders`) is left fully intact and commented out with clear `TODO` markers pointing to the restoration path.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [x] UI/UX improvement
- [ ] Backend/API change
- [ ] Database/Prisma change
- [ ] Refactor
- [ ] Documentation update
- [ ] Configuration/deployment change
- [x] Test update

---

## Changes Made

- **NEW** `src/features/order/mocks/active-orders.mock.ts` — Defines exactly 3 mock orders (`mock-order-1`, `mock-order-2`, `mock-order-3`) with the data shown in the Figma design (BUYING / FUNDING / 124.67 USDC / Alex White / 1.012 USD).
- **NEW** `src/features/order/components/ActiveOrderCard.tsx` — Card component matching the Figma layout: role label, status pill (lime border for FUNDING), large asset amount, inline USDC icon, bank/payment method row, divider, counterparty avatar + name + unit price, relative timestamp, and a visually-enabled but interaction-disabled Open button (prevents invalid navigation on mock data).
- **NEW** `src/features/order/components/ActiveOrdersSection.tsx` — Section wrapper that renders the three mock cards. Backend integration (`useOrders`, `fetchUserOrders`) is commented out with `// TODO: Restore backend active-orders integration after the dashboard UI is approved.` markers so it can be re-enabled without rewriting.
- **NEW** `src/features/order/components/__tests__/ActiveOrdersSection.test.tsx` — 5 unit tests verifying: exactly 3 cards are rendered, section heading is present, card IDs match mock data, mock array length is 3, and all IDs are unique.
- **MODIFIED** `src/app/(protected)/dashboard/page.tsx` — Imports and renders `ActiveOrdersSection`: as a right-side panel on desktop (`md:flex`), and stacked below the wallet section on mobile (`md:hidden`).

---

## Screenshots / Videos

> See attached screenshot in the issue (#78) — the three BUYING / FUNDING / 124.67 USDC cards render side-by-side on desktop matching the Figma reference.

<!-- Paste after screenshot here -->

---

## Testing

### How was this tested?

- [x] Tested locally
- [x] Tested on mobile screen size
- [x] Tested on desktop screen size
- [ ] Tested with wallet connected
- [ ] Tested without wallet connected
- [ ] Tested API manually
- [x] Added or updated automated tests
- [ ] Not applicable

### Test details

1. Ran `npm test` — all **85 tests pass** across 7 test files, including the 5 new `ActiveOrdersSection` tests.
2. Verified three cards render horizontally on desktop (≥ md breakpoint) matching the Figma layout.
3. Verified cards stack / scroll horizontally on mobile (< md breakpoint) and remain readable.
4. Confirmed the Open button does not navigate or throw — it is `disabled` with a tooltip explaining it requires backend integration.
5. Confirmed no console errors are introduced and the existing dashboard wallet section is unaffected.

---

## Frontend Checklist

- [x] UI matches the expected design or issue requirements
- [x] Responsive behavior was verified
- [ ] Loading states are handled *(not applicable — mock data is synchronous; loading state will be added when backend is restored)*
- [ ] Empty states are handled *(not applicable — mock data always has 3 orders; empty state will be added when backend is restored)*
- [ ] Error states are handled *(not applicable — same reason as above)*
- [x] No console errors were introduced
- [x] Existing user flow was not broken

---

## Backend Checklist

- [ ] Endpoint behavior was verified
- [ ] Request validation was added or preserved
- [ ] Error handling was added or preserved
- [ ] Existing API behavior was not broken
- [ ] Database/Prisma changes were reviewed
- [ ] No secrets, private keys, or sensitive values were committed
- [ ] Environment variables were documented if needed

> Not applicable — no backend changes were made. The existing `/orders?userId=` endpoint and `useOrders` hook are untouched.

---

## Database / Prisma Changes

Does this PR include database or Prisma changes?

- [ ] Yes
- [x] No

---

## Environment Variables

Does this PR require new or updated environment variables?

- [ ] Yes
- [x] No

---

## Optional Ikash Traction Support

Please mark your status below:

- [x] I joined the waitlist
- [ ] I connected a wallet
- [ ] I have not done it yet
- [ ] I prefer not to do it