### PR TITLE
Feat/62 security settings tab

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@creit.tech/stellar-wallets-kit':
         specifier: 2.5.0
-        version: 2.5.0(@trezor/connect@9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(near-api-js@5.1.1)(react@19.2.3)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
+        version: 2.5.0(@trezor/connect@9.7.3(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(near-api-js@5.1.1)(react@19.2.3)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.3)
@@ -25,7 +25,7 @@ importers:
         version: 1.16.0(react@19.2.3)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@babel/core@7.29.0(supports-color@7.2.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -46,7 +46,7 @@ importers:
         version: 0.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       socket.io-client:
         specifier: ^4.8.3
-        version: 4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.8.3(bufferutil@4.1.0)(supports-color@7.2.0)(utf-8-validate@6.0.6)
     devDependencies:
       '@next/bundle-analyzer':
         specifier: 16.1.6
@@ -71,10 +71,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       eslint:
         specifier: ^9
-        version: 9.39.4(jiti@2.6.1)
+        version: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -5438,20 +5438,20 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@7.2.0)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5476,19 +5476,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.28.6':
+  '@babel/helper-module-imports@7.28.6(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@7.2.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.28.6(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5515,7 +5515,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.0(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -5523,7 +5523,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5532,9 +5532,9 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)':
+  '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
-      '@coinbase/cdp-sdk': 1.52.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@coinbase/cdp-sdk': 1.52.0(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
@@ -5562,14 +5562,14 @@ snapshots:
 
   '@bufbuild/protobuf@2.12.1': {}
 
-  '@coinbase/cdp-sdk@1.52.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@coinbase/cdp-sdk@1.52.0(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
-      axios: 1.16.0
-      axios-retry: 4.5.0(axios@1.16.0)
+      axios: 1.16.0(debug@4.4.3(supports-color@7.2.0))
+      axios-retry: 4.5.0(axios@1.16.0(debug@4.4.3(supports-color@7.2.0)))
       bs58: 6.0.0
       jose: 6.2.3
       md5: 2.3.0
@@ -5605,7 +5605,7 @@ snapshots:
       - zod
     optional: true
 
-  '@creit.tech/stellar-wallets-kit@2.5.0(@trezor/connect@9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(near-api-js@5.1.1)(react@19.2.3)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)':
+  '@creit.tech/stellar-wallets-kit@2.5.0(@trezor/connect@9.7.3(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(near-api-js@5.1.1)(react@19.2.3)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@albedo-link/intent': 0.12.0
       '@creit.tech/xbull-wallet-connect': 0.4.0
@@ -5615,10 +5615,10 @@ snapshots:
       '@ledgerhq/hw-transport-webusb': 6.29.12
       '@lobstrco/signer-extension-api': 2.0.0
       '@preact/signals': 2.9.0(preact@10.29.7)
-      '@reown/appkit': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@reown/appkit': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
       '@stellar/freighter-api': 6.0.0
-      '@stellar/stellar-sdk': 16.1.0
-      '@trezor/connect-plugin-stellar': 10.0.0-alpha.1(@stellar/stellar-sdk@16.1.0)(@trezor/connect@9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(tslib@2.8.1)
+      '@stellar/stellar-sdk': 16.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      '@trezor/connect-plugin-stellar': 10.0.0-alpha.1(@stellar/stellar-sdk@16.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0))(@trezor/connect@9.7.3(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(tslib@2.8.1)
       '@trezor/connect-web': 10.0.0-alpha.1(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
       '@twind/core': 1.1.3(typescript@5.9.3)
       '@twind/preset-autoprefix': 1.0.7(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
@@ -5732,17 +5732,17 @@ snapshots:
 
   '@emurgo/cardano-serialization-lib-nodejs@13.2.0': {}
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))':
     dependencies:
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@7.2.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -5755,10 +5755,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@7.2.0)':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -6312,12 +6312,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)':
+  '@reown/appkit-pay@1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-ui': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)
       lit: 3.3.0
       valtio: 2.1.7(@types/react@19.2.14)(react@19.2.3)
     transitivePeerDependencies:
@@ -6356,13 +6356,13 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)':
+  '@reown/appkit-scaffold-ui@1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-pay': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@reown/appkit-pay': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-ui': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -6434,7 +6434,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)':
+  '@reown/appkit-utils@1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -6446,7 +6446,7 @@ snapshots:
       valtio: 2.1.7(@types/react@19.2.14)(react@19.2.3)
       viem: 2.55.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
     optionalDependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -6493,15 +6493,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)':
+  '@reown/appkit@1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-pay': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@reown/appkit-pay': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.8.21
-      '@reown/appkit-scaffold-ui': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)
+      '@reown/appkit-scaffold-ui': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)
       '@reown/appkit-ui': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.21(@types/react@19.2.14)(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.14)(react@19.2.3))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       bs58: 6.0.0
@@ -6658,10 +6658,10 @@ snapshots:
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
   '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
@@ -6696,6 +6696,7 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+    optional: true
 
   '@solana/addresses@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -6719,6 +6720,7 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+    optional: true
 
   '@solana/assertions@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -6730,6 +6732,7 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+    optional: true
 
   '@solana/buffer-layout@4.0.1':
     dependencies:
@@ -6745,6 +6748,7 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+    optional: true
 
   '@solana/codecs-data-structures@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -6760,6 +6764,7 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+    optional: true
 
   '@solana/codecs-numbers@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -6773,6 +6778,7 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+    optional: true
 
   '@solana/codecs-strings@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -6790,6 +6796,7 @@ snapshots:
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
+    optional: true
 
   '@solana/codecs@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -6813,6 +6820,7 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+    optional: true
 
   '@solana/errors@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -6826,6 +6834,7 @@ snapshots:
       commander: 14.0.2
     optionalDependencies:
       typescript: 5.9.3
+    optional: true
 
   '@solana/fast-stable-stringify@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -6961,6 +6970,7 @@ snapshots:
   '@solana/nominal-types@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
+    optional: true
 
   '@solana/offchain-messages@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -7000,6 +7010,7 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+    optional: true
 
   '@solana/plugin-core@5.5.1(typescript@5.9.3)':
     optionalDependencies:
@@ -7085,6 +7096,7 @@ snapshots:
   '@solana/rpc-spec-types@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
+    optional: true
 
   '@solana/rpc-spec@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -7098,6 +7110,7 @@ snapshots:
       '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+    optional: true
 
   '@solana/rpc-subscriptions-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -7273,6 +7286,7 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+    optional: true
 
   '@solana/rpc@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -7369,6 +7383,7 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+    optional: true
 
   '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
@@ -7535,10 +7550,10 @@ snapshots:
       buffer: 6.0.3
       sha.js: 2.4.12
 
-  '@stellar/stellar-sdk@14.2.0':
+  '@stellar/stellar-sdk@14.2.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
       '@stellar/stellar-base': 14.1.0
-      axios: 1.18.1
+      axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       bignumber.js: 9.3.1
       eventsource: 2.0.2
       feaxios: 0.0.23
@@ -7549,12 +7564,12 @@ snapshots:
       - debug
       - supports-color
 
-  '@stellar/stellar-sdk@16.1.0':
+  '@stellar/stellar-sdk@16.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
       '@noble/ed25519': 3.1.0
       '@noble/hashes': 2.2.0
       '@stellar/js-xdr': 4.0.0
-      axios: 1.18.0
+      axios: 1.18.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       base32.js: 0.1.0
       bignumber.js: 11.1.5
       buffer: 6.0.3
@@ -7692,10 +7707,10 @@ snapshots:
       '@trezor/utxo-lib': 2.5.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@trezor/blockchain-link-utils@1.5.2(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)':
+  '@trezor/blockchain-link-utils@1.5.2(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)(tslib@2.8.1)(utf-8-validate@6.0.6)':
     dependencies:
       '@mobily/ts-belt': 3.13.1
-      '@stellar/stellar-sdk': 14.2.0
+      '@stellar/stellar-sdk': 14.2.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       '@trezor/env-utils': 1.5.0(tslib@2.8.1)
       '@trezor/protobuf': 1.5.2(tslib@2.8.1)
       '@trezor/utils': 9.5.0(tslib@2.8.1)
@@ -7710,24 +7725,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@trezor/blockchain-link@2.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@trezor/blockchain-link@2.6.2(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
       '@solana-program/stake': 0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
       '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@stellar/stellar-sdk': 14.2.0
+      '@stellar/stellar-sdk': 14.2.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       '@trezor/blockchain-link-types': 1.5.1(tslib@2.8.1)
-      '@trezor/blockchain-link-utils': 1.5.2(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
+      '@trezor/blockchain-link-utils': 1.5.2(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
       '@trezor/env-utils': 1.5.0(tslib@2.8.1)
       '@trezor/utils': 9.5.0(tslib@2.8.1)
       '@trezor/utxo-lib': 2.5.0(tslib@2.8.1)
       '@trezor/websocket-client': 1.3.0(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
       '@types/web': 0.0.197
       crypto-browserify: 3.12.0
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
       stream-browserify: 3.0.0
       tslib: 2.8.1
       xrpl: 4.4.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -7774,10 +7789,10 @@ snapshots:
       '@trezor/utils': 10.0.0-alpha.1(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@trezor/connect-plugin-stellar@10.0.0-alpha.1(@stellar/stellar-sdk@16.1.0)(@trezor/connect@9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(tslib@2.8.1)':
+  '@trezor/connect-plugin-stellar@10.0.0-alpha.1(@stellar/stellar-sdk@16.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0))(@trezor/connect@9.7.3(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(tslib@2.8.1)':
     dependencies:
-      '@stellar/stellar-sdk': 16.1.0
-      '@trezor/connect': 9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@stellar/stellar-sdk': 16.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      '@trezor/connect': 9.7.3(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@trezor/utils': 10.0.0-alpha.1(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -7791,7 +7806,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@trezor/connect@9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@trezor/connect@9.7.3(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@ethereumjs/common': 10.1.2
       '@ethereumjs/tx': 10.1.2
@@ -7802,11 +7817,11 @@ snapshots:
       '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
       '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
       '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@trezor/blockchain-link': 2.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@trezor/blockchain-link': 2.6.2(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(fastestsmallesttextencoderdecoder@1.0.22)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@trezor/blockchain-link-types': 1.5.1(tslib@2.8.1)
-      '@trezor/blockchain-link-utils': 1.5.2(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
+      '@trezor/blockchain-link-utils': 1.5.2(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
       '@trezor/connect-analytics': 1.4.0(tslib@2.8.1)
       '@trezor/connect-common': 0.5.1(tslib@2.8.1)
       '@trezor/crypto-utils': 1.2.0(tslib@2.8.1)
@@ -8079,15 +8094,15 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
-  '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.57.0
-      '@typescript-eslint/type-utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.0
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -8095,23 +8110,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.0
       '@typescript-eslint/types': 8.57.0
-      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.0(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.0
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.57.0(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -8125,13 +8140,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.57.0
-      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
+      '@typescript-eslint/typescript-estree': 8.57.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8139,28 +8154,28 @@ snapshots:
 
   '@typescript-eslint/types@8.57.0': {}
 
-  '@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.57.0(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.57.0(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/visitor-keys': 8.57.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.4
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))
       '@typescript-eslint/scope-manager': 8.57.0
       '@typescript-eslint/types': 8.57.0
-      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.6.1)
+      '@typescript-eslint/typescript-estree': 8.57.0(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -8819,9 +8834,9 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8948,36 +8963,36 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios-retry@4.5.0(axios@1.16.0):
+  axios-retry@4.5.0(axios@1.16.0(debug@4.4.3(supports-color@7.2.0))):
     dependencies:
-      axios: 1.16.0
+      axios: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       is-retry-allowed: 2.2.0
     optional: true
 
-  axios@1.16.0:
+  axios@1.16.0(debug@4.4.3(supports-color@7.2.0)):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
     optional: true
 
-  axios@1.18.0:
+  axios@1.18.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  axios@1.18.1:
+  axios@1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -9229,7 +9244,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
-  commander@14.0.2: {}
+  commander@14.0.2:
+    optional: true
 
   commander@14.0.3: {}
 
@@ -9389,13 +9405,17 @@ snapshots:
 
   debounce@1.2.1: {}
 
-  debug@3.2.7:
+  debug@3.2.7(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   decamelize@1.2.0: {}
 
@@ -9491,10 +9511,10 @@ snapshots:
 
   encode-utf8@1.0.3: {}
 
-  engine.io-client@6.6.6(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  engine.io-client@6.6.6(bufferutil@4.1.0)(supports-color@7.2.0)(utf-8-validate@6.0.6):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       engine.io-parser: 5.2.3
       ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xmlhttprequest-ssl: 2.1.2
@@ -9632,18 +9652,18 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.6
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
+      eslint-import-resolver-node: 0.3.9(supports-color@7.2.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
       globals: 16.4.0
-      typescript-eslint: 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9652,52 +9672,52 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-import-resolver-node@0.3.9:
+  eslint-import-resolver-node@0.3.9(supports-color@7.2.0):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@7.2.0)
       is-core-module: 2.16.1
       resolve: 1.22.11
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       get-tsconfig: 4.13.6
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9(supports-color@7.2.0))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@7.2.0)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
+      eslint-import-resolver-node: 0.3.9(supports-color@7.2.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@7.2.0)
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
+      eslint-import-resolver-node: 0.3.9(supports-color@7.2.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9(supports-color@7.2.0))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9709,13 +9729,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -9725,7 +9745,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -9734,18 +9754,18 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/parser': 7.29.0
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       hermes-parser: 0.25.1
       zod: 4.3.6
       zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -9753,7 +9773,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.1
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -9778,14 +9798,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4(jiti@2.6.1):
+  eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@7.2.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@7.2.0)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -9795,7 +9815,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -9935,7 +9955,9 @@ snapshots:
 
   flatted@3.4.1: {}
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@7.2.0)
 
   for-each@0.3.5:
     dependencies:
@@ -10127,10 +10149,10 @@ snapshots:
       statuses: 1.5.0
       toidentifier: 1.0.0
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@7.2.0):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10719,7 +10741,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@babel/core@7.29.0(supports-color@7.2.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -10728,7 +10750,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.29.0(supports-color@7.2.0))(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -11502,28 +11524,28 @@ snapshots:
 
   smol-toml@1.7.0: {}
 
-  socket.io-client@4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  socket.io-client@4.8.3(bufferutil@4.1.0)(supports-color@7.2.0)(utf-8-validate@6.0.6):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3
-      engine.io-client: 6.6.6(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      socket.io-parser: 4.2.7
+      debug: 4.4.3(supports-color@7.2.0)
+      engine.io-client: 6.6.6(bufferutil@4.1.0)(supports-color@7.2.0)(utf-8-validate@6.0.6)
+      socket.io-parser: 4.2.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.7:
+  socket.io-parser@4.2.7(supports-color@7.2.0):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  socks-proxy-agent@8.0.5:
+  socks-proxy-agent@8.0.5(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
@@ -11642,12 +11664,12 @@ snapshots:
 
   style-vendorizer@2.2.3: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.29.0(supports-color@7.2.0))(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
     optionalDependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
   superstruct@2.0.2: {}
 
@@ -11799,13 +11821,13 @@ snapshots:
 
   typeforce@1.18.0: {}
 
-  typescript-eslint@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.6.1)
+      '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color

--- a/src/app/(protected)/settings/__tests__/SecurityTab.test.tsx
+++ b/src/app/(protected)/settings/__tests__/SecurityTab.test.tsx
@@ -18,8 +18,8 @@ describe("SecurityTab", () => {
     it("renders all security sections", () => {
         render(<SecurityTab />);
 
-        expect(screen.getByTestId("connected-wallet-card")).toBeInTheDocument();
-        expect(screen.getByTestId("security-preferences")).toBeInTheDocument();
-        expect(screen.getByTestId("recent-sessions-list")).toBeInTheDocument();
+        expect(screen.getByTestId("connected-wallet-card")).toBeTruthy();
+        expect(screen.getByTestId("security-preferences")).toBeTruthy();
+        expect(screen.getByTestId("recent-sessions-list")).toBeTruthy();
     });
 });

--- a/src/app/(protected)/settings/__tests__/SecurityTab.test.tsx
+++ b/src/app/(protected)/settings/__tests__/SecurityTab.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SecurityTab } from "../components/SecurityTab";
+
+vi.mock("@/features/settings/components/ConnectedWalletCard", () => ({
+    ConnectedWalletCard: () => <div data-testid="connected-wallet-card">Connected Wallet Card</div>,
+}));
+
+vi.mock("@/features/settings/components/SecurityPreferences", () => ({
+    SecurityPreferences: () => <div data-testid="security-preferences">Security Preferences</div>,
+}));
+
+vi.mock("@/features/settings/components/RecentSessionsList", () => ({
+    RecentSessionsList: () => <div data-testid="recent-sessions-list">Recent Sessions List</div>,
+}));
+
+describe("SecurityTab", () => {
+    it("renders all security sections", () => {
+        render(<SecurityTab />);
+
+        expect(screen.getByTestId("connected-wallet-card")).toBeInTheDocument();
+        expect(screen.getByTestId("security-preferences")).toBeInTheDocument();
+        expect(screen.getByTestId("recent-sessions-list")).toBeInTheDocument();
+    });
+});

--- a/src/app/(protected)/settings/components/SecurityTab.tsx
+++ b/src/app/(protected)/settings/components/SecurityTab.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { ConnectedWalletCard } from "@/features/settings/components/ConnectedWalletCard";
+import { SecurityPreferences } from "@/features/settings/components/SecurityPreferences";
+import { RecentSessionsList } from "@/features/settings/components/RecentSessionsList";
+
+export function SecurityTab() {
+    return (
+        <div className="mx-auto w-full max-w-[1540px] px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+            <div className="space-y-6">
+                <ConnectedWalletCard />
+                <SecurityPreferences />
+                <RecentSessionsList />
+            </div>
+        </div>
+    );
+}

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -5,8 +5,12 @@ import { Aside } from "../../components/Aside";
 import { Header } from "../../components/Header";
 import { ProfileTab } from "./components/ProfileTab";
 import { getRovingFocusIndex } from "@/utils/keyboardNavigation";
+import { SecurityTab } from "./components/SecurityTab";
 
-const tabs = [{ id: "profile", label: "Profile" }];
+const tabs = [
+    { id: "profile", label: "Profile" },
+    { id: "security", label: "Security" },
+];
 
 export default function SettingsPage() {
     const [activeTab, setActiveTab] = useState("profile");
@@ -62,6 +66,7 @@ export default function SettingsPage() {
                     className="flex-1 overflow-y-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#BCED09]"
                 >
                     {activeTab === "profile" && <ProfileTab />}
+                    {activeTab === "security" && <SecurityTab />}
                     {activeTab === "wallets" && (
                         <div className="px-4 py-16 text-[#8F8389] md:px-12">
                             Wallets settings configuration pending MVP integration.
@@ -70,11 +75,6 @@ export default function SettingsPage() {
                     {activeTab === "payments" && (
                         <div className="px-4 py-16 text-[#8F8389] md:px-12">
                             Payments settings configuration pending MVP integration.
-                        </div>
-                    )}
-                    {activeTab === "security" && (
-                        <div className="px-4 py-16 text-[#8F8389] md:px-12">
-                            Security settings configuration pending MVP integration.
                         </div>
                     )}
                 </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 import { NotificationProvider } from "@/features/notifications";
 import { CookieConsentBanner } from "./components/CookieConsentBanner";
 import { UserProvider } from "../features/user/presentation/context/UserContext";
-import { WalletProvider } from "../features/wallet";
+import { WalletProvider, WrongNetworkBanner } from "../features/wallet";
 import { Space_Grotesk } from "next/font/google";
 import { QueryProvider } from "./providers/QueryProvider";
 
@@ -31,6 +31,7 @@ export default function RootLayout({
           <NotificationProvider>
             <UserProvider>
               <WalletProvider>
+                <WrongNetworkBanner />
                 {children}
                 <CookieConsentBanner />
               </WalletProvider>

--- a/src/features/settings/components/ConnectedWalletCard.tsx
+++ b/src/features/settings/components/ConnectedWalletCard.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import { Wallet, Copy, Check, Eye, EyeOff, ShieldCheck, AlertCircle } from "lucide-react";
+import { useWalletContext } from "@/features/wallet/presentation/context/WalletContext";
+
+export function ConnectedWalletCard() {
+    const { publicKey, walletId, isConnected } = useWalletContext();
+    const [copied, setCopied] = useState(false);
+    const [showFullAddress, setShowFullAddress] = useState(false);
+
+    const handleCopy = async () => {
+        if (!publicKey) return;
+        try {
+            await navigator.clipboard.writeText(publicKey);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            // Fallback if clipboard API is not available
+        }
+    };
+
+    const shortenedAddress = publicKey
+        ? `${publicKey.slice(0, 6)}...${publicKey.slice(-6)}`
+        : "";
+
+    return (
+        <div className="rounded-xl border border-[#1A1F26] bg-[#0E121B]/60 p-6 backdrop-blur-sm">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[#1A1F26] pb-4">
+                <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#BCED09]/10 text-[#BCED09]">
+                        <Wallet className="h-5 w-5" />
+                    </div>
+                    <div>
+                        <h2 className="text-[17px] font-semibold text-white">Connected Wallet</h2>
+                        <p className="text-xs text-[#8F8389]">
+                            Stellar account managing your on-chain assets and escrows
+                        </p>
+                    </div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                    {isConnected && publicKey ? (
+                        <span className="inline-flex items-center gap-1.5 rounded-full bg-[#10B981]/15 px-3 py-1 text-xs font-medium text-[#10B981]">
+                            <ShieldCheck className="h-3.5 w-3.5" />
+                            Connected
+                        </span>
+                    ) : (
+                        <span className="inline-flex items-center gap-1.5 rounded-full bg-[#F59E0B]/15 px-3 py-1 text-xs font-medium text-[#F59E0B]">
+                            <AlertCircle className="h-3.5 w-3.5" />
+                            Not Connected
+                        </span>
+                    )}
+                </div>
+            </div>
+
+            <div className="pt-5">
+                {isConnected && publicKey ? (
+                    <div className="space-y-4">
+                        <div>
+                            <span className="text-xs font-medium text-[#8F8389]">Stellar Public Key</span>
+                            <div className="mt-1.5 flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-lg border border-[#1A1F26] bg-[#05070B] p-3.5">
+                                <div className="font-mono text-sm text-white break-all select-all">
+                                    {showFullAddress ? publicKey : shortenedAddress}
+                                </div>
+                                <div className="flex items-center gap-2 shrink-0">
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowFullAddress((prev) => !prev)}
+                                        className="inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-[#8F8389] hover:bg-[#1A1F26] hover:text-white transition cursor-pointer"
+                                        aria-label={showFullAddress ? "Hide full address" : "View full address"}
+                                    >
+                                        {showFullAddress ? (
+                                            <>
+                                                <EyeOff className="h-3.5 w-3.5" />
+                                                Hide
+                                            </>
+                                        ) : (
+                                            <>
+                                                <Eye className="h-3.5 w-3.5" />
+                                                Full Key
+                                            </>
+                                        )}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={handleCopy}
+                                        className="inline-flex items-center gap-1 rounded-md bg-[#BCED09]/15 px-3 py-1.5 text-xs font-medium text-[#BCED09] hover:bg-[#BCED09]/25 transition cursor-pointer"
+                                        aria-label="Copy wallet address"
+                                    >
+                                        {copied ? (
+                                            <>
+                                                <Check className="h-3.5 w-3.5" />
+                                                Copied
+                                            </>
+                                        ) : (
+                                            <>
+                                                <Copy className="h-3.5 w-3.5" />
+                                                Copy
+                                            </>
+                                        )}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+
+                        {walletId && (
+                            <div className="text-xs text-[#8F8389]">
+                                Wallet Provider: <span className="font-medium text-white capitalize">{walletId}</span>
+                            </div>
+                        )}
+
+                        <div className="rounded-lg bg-[#BCED09]/5 border border-[#BCED09]/10 p-3 text-xs text-[#8F8389]">
+                            🔒 <strong className="text-white">Security Note:</strong> Only your public key is stored for authentication and escrow routing. Your private keys never leave your wallet.
+                        </div>
+                    </div>
+                ) : (
+                    <div className="py-6 text-center text-sm text-[#8F8389]">
+                        No Stellar wallet is currently connected.
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/features/settings/components/RecentSessionsList.tsx
+++ b/src/features/settings/components/RecentSessionsList.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Laptop, Smartphone, Globe, Clock, ShieldCheck, RefreshCw } from "lucide-react";
+import { useRecentSessions } from "../hooks/useRecentSessions";
+
+export function RecentSessionsList() {
+    const { sessions, isLoading, error, reload } = useRecentSessions();
+
+    const formatDate = (dateStr: string) => {
+        try {
+            const date = new Date(dateStr);
+            if (isNaN(date.getTime())) return dateStr;
+            return date.toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+                hour: "numeric",
+                minute: "2-digit",
+            });
+        } catch {
+            return dateStr;
+        }
+    };
+
+    return (
+        <div className="rounded-xl border border-[#1A1F26] bg-[#0E121B]/60 p-6 backdrop-blur-sm">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[#1A1F26] pb-4">
+                <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#BCED09]/10 text-[#BCED09]">
+                        <Globe className="h-5 w-5" />
+                    </div>
+                    <div>
+                        <h2 className="text-[17px] font-semibold text-white">Recent Sessions & Login Activity</h2>
+                        <p className="text-xs text-[#8F8389]">
+                            Devices and browsers that recently connected to your iKash profile
+                        </p>
+                    </div>
+                </div>
+
+                <button
+                    type="button"
+                    onClick={() => void reload()}
+                    disabled={isLoading}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-[#1A1F26] bg-[#161B22] px-3 py-1.5 text-xs font-medium text-[#8F8389] hover:text-white hover:bg-[#1F2937] transition cursor-pointer disabled:opacity-50"
+                    aria-label="Refresh recent sessions"
+                >
+                    <RefreshCw className={`h-3.5 w-3.5 ${isLoading ? "animate-spin" : ""}`} />
+                    Refresh
+                </button>
+            </div>
+
+            <div className="pt-4">
+                {isLoading ? (
+                    <div className="space-y-3 py-2">
+                        {[1, 2].map((i) => (
+                            <div
+                                key={i}
+                                className="flex items-center justify-between rounded-lg border border-[#1A1F26] bg-[#05070B] p-4 animate-pulse"
+                            >
+                                <div className="space-y-2">
+                                    <div className="h-4 w-32 bg-[#1A1F26] rounded" />
+                                    <div className="h-3 w-48 bg-[#1A1F26]/60 rounded" />
+                                </div>
+                                <div className="h-6 w-20 bg-[#1A1F26] rounded-full" />
+                            </div>
+                        ))}
+                    </div>
+                ) : sessions.length === 0 ? (
+                    <div className="py-8 text-center text-sm text-[#8F8389]">
+                        No recent session activity is available.
+                    </div>
+                ) : (
+                    <div className="space-y-3">
+                        {sessions.map((session) => {
+                            const isMobile =
+                                /mobile|android|iphone|ipad/i.test(session.device) ||
+                                (session.os && /android|ios/i.test(session.os));
+                            const Icon = isMobile ? Smartphone : Laptop;
+
+                            return (
+                                <div
+                                    key={session.id}
+                                    className={`flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-lg border p-4 transition ${
+                                        session.isCurrent
+                                            ? "border-[#BCED09]/30 bg-[#BCED09]/5"
+                                            : "border-[#1A1F26] bg-[#05070B]"
+                                    }`}
+                                >
+                                    <div className="flex items-start gap-3.5">
+                                        <div
+                                            className={`flex h-9 w-9 items-center justify-center rounded-lg shrink-0 ${
+                                                session.isCurrent
+                                                    ? "bg-[#BCED09]/20 text-[#BCED09]"
+                                                    : "bg-[#161B22] text-[#8F8389]"
+                                            }`}
+                                        >
+                                            <Icon className="h-5 w-5" />
+                                        </div>
+                                        <div>
+                                            <div className="flex items-center gap-2">
+                                                <h3 className="text-sm font-medium text-white">
+                                                    {session.device}
+                                                </h3>
+                                                {session.isCurrent && (
+                                                    <span className="inline-flex items-center gap-1 rounded-full bg-[#BCED09]/15 px-2 py-0.5 text-[11px] font-semibold text-[#BCED09]">
+                                                        <ShieldCheck className="h-3 w-3" />
+                                                        Current session
+                                                    </span>
+                                                )}
+                                            </div>
+                                            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[#8F8389]">
+                                                <span className="flex items-center gap-1">
+                                                    <Clock className="h-3 w-3" />
+                                                    {formatDate(session.createdAt)}
+                                                </span>
+                                                {session.ipAddress && (
+                                                    <span>IP: {session.ipAddress}</span>
+                                                )}
+                                                {session.location && (
+                                                    <span>• {session.location}</span>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    {!session.isCurrent && (
+                                        <div className="self-end sm:self-center">
+                                            <span
+                                                className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${
+                                                    session.status === "active"
+                                                        ? "bg-[#10B981]/15 text-[#10B981]"
+                                                        : session.status === "revoked"
+                                                        ? "bg-[#EF4444]/15 text-[#EF4444]"
+                                                        : "bg-[#8F8389]/15 text-[#8F8389]"
+                                                }`}
+                                            >
+                                                {session.status}
+                                            </span>
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+
+            {error && (
+                <div className="mt-4 rounded-lg bg-[#EF4444]/10 border border-[#EF4444]/20 p-3 text-xs text-[#F87171]">
+                    {error}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/features/settings/components/SecurityPreferences.tsx
+++ b/src/features/settings/components/SecurityPreferences.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Bell, Loader2, ShieldCheck, Mail, AlertTriangle, ArrowRightLeft, Lock } from "lucide-react";
+import { useSecuritySettings } from "../hooks/useSecuritySettings";
+import type { SecurityPreferences as PreferencesType } from "../types/security-settings.types";
+
+interface PreferenceItem {
+    key: keyof PreferencesType;
+    title: string;
+    description: string;
+    icon: React.ComponentType<{ className?: string }>;
+}
+
+const PREFERENCE_ITEMS: PreferenceItem[] = [
+    {
+        key: "securityUpdates",
+        title: "Security Updates",
+        description: "Receive critical security patches, account safety notices, and protocol changes.",
+        icon: ShieldCheck,
+    },
+    {
+        key: "loginAlerts",
+        title: "Login Alerts",
+        description: "Get notified when a new wallet session or signature challenge is completed.",
+        icon: Lock,
+    },
+    {
+        key: "transactionNotifications",
+        title: "Transaction Notifications",
+        description: "Real-time alerts when Stellar transactions or deposits are confirmed on-chain.",
+        icon: ArrowRightLeft,
+    },
+    {
+        key: "escrowStatusUpdates",
+        title: "Escrow Status Updates",
+        description: "Notifications when escrow funds are deposited, locked, released, or refunded.",
+        icon: AlertTriangle,
+    },
+    {
+        key: "emailNotifications",
+        title: "Email Notifications",
+        description: "Receive security alerts and transaction receipts via your verified email address.",
+        icon: Mail,
+    },
+];
+
+export function SecurityPreferences() {
+    const { preferences, isLoading, error, updatingKeys, updatePreference } = useSecuritySettings();
+
+    return (
+        <div className="rounded-xl border border-[#1A1F26] bg-[#0E121B]/60 p-6 backdrop-blur-sm">
+            <div className="flex items-center gap-3 border-b border-[#1A1F26] pb-4">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#BCED09]/10 text-[#BCED09]">
+                    <Bell className="h-5 w-5" />
+                </div>
+                <div>
+                    <h2 className="text-[17px] font-semibold text-white">Notification & Security Preferences</h2>
+                    <p className="text-xs text-[#8F8389]">
+                        Manage which security alerts and activity notifications you receive
+                    </p>
+                </div>
+            </div>
+
+            <div className="pt-4 divide-y divide-[#1A1F26]">
+                {isLoading ? (
+                    <div className="space-y-4 py-4">
+                        {[1, 2, 3, 4, 5].map((i) => (
+                            <div key={i} className="flex items-center justify-between py-3 animate-pulse">
+                                <div className="space-y-2">
+                                    <div className="h-4 w-40 bg-[#1A1F26] rounded" />
+                                    <div className="h-3 w-64 bg-[#1A1F26]/60 rounded" />
+                                </div>
+                                <div className="h-6 w-11 bg-[#1A1F26] rounded-full" />
+                            </div>
+                        ))}
+                    </div>
+                ) : (
+                    PREFERENCE_ITEMS.map(({ key, title, description, icon: Icon }) => {
+                        const isEnabled = preferences[key];
+                        const isUpdating = !!updatingKeys[key];
+
+                        return (
+                            <div
+                                key={key}
+                                className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 py-4"
+                            >
+                                <div className="flex items-start gap-3.5 max-w-xl">
+                                    <div className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-md bg-[#161B22] text-[#8F8389] shrink-0">
+                                        <Icon className="h-4 w-4 text-[#BCED09]" />
+                                    </div>
+                                    <div>
+                                        <label
+                                            htmlFor={`pref-toggle-${key}`}
+                                            className="text-sm font-medium text-white cursor-pointer"
+                                        >
+                                            {title}
+                                        </label>
+                                        <p className="text-xs text-[#8F8389] mt-0.5 leading-relaxed">
+                                            {description}
+                                        </p>
+                                    </div>
+                                </div>
+
+                                <div className="flex items-center gap-3 self-end sm:self-center shrink-0">
+                                    {isUpdating && (
+                                        <Loader2 className="h-4 w-4 animate-spin text-[#BCED09]" />
+                                    )}
+                                    <button
+                                        id={`pref-toggle-${key}`}
+                                        type="button"
+                                        role="switch"
+                                        aria-checked={isEnabled}
+                                        aria-label={`Toggle ${title}`}
+                                        disabled={isUpdating}
+                                        onClick={() => void updatePreference(key, !isEnabled)}
+                                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 ${
+                                            isEnabled ? "bg-[#BCED09]" : "bg-[#1F2937]"
+                                        }`}
+                                    >
+                                        <span
+                                            className={`inline-block h-4 w-4 transform rounded-full bg-black transition-transform ${
+                                                isEnabled ? "translate-x-6" : "translate-x-1 bg-[#8F8389]"
+                                            }`}
+                                        />
+                                    </button>
+                                </div>
+                            </div>
+                        );
+                    })
+                )}
+            </div>
+
+            {error && (
+                <div className="mt-4 rounded-lg bg-[#EF4444]/10 border border-[#EF4444]/20 p-3 text-xs text-[#F87171]">
+                    {error}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/features/settings/components/__tests__/ConnectedWalletCard.test.tsx
+++ b/src/features/settings/components/__tests__/ConnectedWalletCard.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ConnectedWalletCard } from "../ConnectedWalletCard";
 import * as walletContextModule from "@/features/wallet/presentation/context/WalletContext";
+import type { WalletContext } from "@/features/wallet";
 
 vi.mock("@/features/wallet/presentation/context/WalletContext", () => ({
     useWalletContext: vi.fn(),
@@ -17,12 +18,12 @@ describe("ConnectedWalletCard", () => {
             publicKey: null,
             walletId: null,
             isConnected: false,
-        } as any);
+        } as unknown as WalletContext);
 
         render(<ConnectedWalletCard />);
 
-        expect(screen.getByText("Not Connected")).toBeInTheDocument();
-        expect(screen.getByText("No Stellar wallet is currently connected.")).toBeInTheDocument();
+        expect(screen.getByText("Not Connected")).toBeTruthy();
+        expect(screen.getByText("No Stellar wallet is currently connected.")).toBeTruthy();
     });
 
     it("displays truncated address and allows toggling full address", () => {
@@ -31,18 +32,18 @@ describe("ConnectedWalletCard", () => {
             publicKey: fullKey,
             walletId: "freighter",
             isConnected: true,
-        } as any);
+        } as unknown as WalletContext);
 
         render(<ConnectedWalletCard />);
 
-        expect(screen.getByText("Connected")).toBeInTheDocument();
-        expect(screen.getByText("GABC12...012XYZ")).toBeInTheDocument();
+        expect(screen.getByText("Connected")).toBeTruthy();
+        expect(screen.getByText("GABC12...012XYZ")).toBeTruthy();
 
         // Toggle full key
         const toggleBtn = screen.getByRole("button", { name: /view full address/i });
         fireEvent.click(toggleBtn);
 
-        expect(screen.getByText(fullKey)).toBeInTheDocument();
+        expect(screen.getByText(fullKey)).toBeTruthy();
     });
 
     it("copies public key to clipboard when Copy button is clicked", async () => {
@@ -58,7 +59,7 @@ describe("ConnectedWalletCard", () => {
             publicKey: fullKey,
             walletId: "freighter",
             isConnected: true,
-        } as any);
+        } as unknown as WalletContext);
 
         render(<ConnectedWalletCard />);
 
@@ -66,6 +67,6 @@ describe("ConnectedWalletCard", () => {
         fireEvent.click(copyBtn);
 
         expect(writeTextMock).toHaveBeenCalledWith(fullKey);
-        expect(await screen.findByText("Copied")).toBeInTheDocument();
+        expect(await screen.findByText("Copied")).toBeTruthy();
     });
 });

--- a/src/features/settings/components/__tests__/ConnectedWalletCard.test.tsx
+++ b/src/features/settings/components/__tests__/ConnectedWalletCard.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConnectedWalletCard } from "../ConnectedWalletCard";
+import * as walletContextModule from "@/features/wallet/presentation/context/WalletContext";
+
+vi.mock("@/features/wallet/presentation/context/WalletContext", () => ({
+    useWalletContext: vi.fn(),
+}));
+
+describe("ConnectedWalletCard", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("displays not connected message when wallet is disconnected", () => {
+        vi.spyOn(walletContextModule, "useWalletContext").mockReturnValue({
+            publicKey: null,
+            walletId: null,
+            isConnected: false,
+        } as any);
+
+        render(<ConnectedWalletCard />);
+
+        expect(screen.getByText("Not Connected")).toBeInTheDocument();
+        expect(screen.getByText("No Stellar wallet is currently connected.")).toBeInTheDocument();
+    });
+
+    it("displays truncated address and allows toggling full address", () => {
+        const fullKey = "GABC1234567890123456789012345678901234567890123456789012XYZ";
+        vi.spyOn(walletContextModule, "useWalletContext").mockReturnValue({
+            publicKey: fullKey,
+            walletId: "freighter",
+            isConnected: true,
+        } as any);
+
+        render(<ConnectedWalletCard />);
+
+        expect(screen.getByText("Connected")).toBeInTheDocument();
+        expect(screen.getByText("GABC12...012XYZ")).toBeInTheDocument();
+
+        // Toggle full key
+        const toggleBtn = screen.getByRole("button", { name: /view full address/i });
+        fireEvent.click(toggleBtn);
+
+        expect(screen.getByText(fullKey)).toBeInTheDocument();
+    });
+
+    it("copies public key to clipboard when Copy button is clicked", async () => {
+        const writeTextMock = vi.fn().mockResolvedValue(undefined);
+        Object.assign(navigator, {
+            clipboard: {
+                writeText: writeTextMock,
+            },
+        });
+
+        const fullKey = "GABC1234567890123456789012345678901234567890123456789012XYZ";
+        vi.spyOn(walletContextModule, "useWalletContext").mockReturnValue({
+            publicKey: fullKey,
+            walletId: "freighter",
+            isConnected: true,
+        } as any);
+
+        render(<ConnectedWalletCard />);
+
+        const copyBtn = screen.getByRole("button", { name: /copy wallet address/i });
+        fireEvent.click(copyBtn);
+
+        expect(writeTextMock).toHaveBeenCalledWith(fullKey);
+        expect(await screen.findByText("Copied")).toBeInTheDocument();
+    });
+});

--- a/src/features/settings/components/__tests__/RecentSessionsList.test.tsx
+++ b/src/features/settings/components/__tests__/RecentSessionsList.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RecentSessionsList } from "../RecentSessionsList";
+import * as sessionsHooksModule from "../../hooks/useRecentSessions";
+
+vi.mock("../../hooks/useRecentSessions", () => ({
+    useRecentSessions: vi.fn(),
+}));
+
+describe("RecentSessionsList", () => {
+    const mockReload = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders empty state when there are no sessions", () => {
+        vi.spyOn(sessionsHooksModule, "useRecentSessions").mockReturnValue({
+            sessions: [],
+            isLoading: false,
+            error: null,
+            reload: mockReload,
+        });
+
+        render(<RecentSessionsList />);
+
+        expect(screen.getByText("No recent session activity is available.")).toBeInTheDocument();
+    });
+
+    it("renders sessions with current session badge clearly identified", () => {
+        vi.spyOn(sessionsHooksModule, "useRecentSessions").mockReturnValue({
+            sessions: [
+                {
+                    id: "session-1",
+                    createdAt: "2026-07-14T09:30:00.000Z",
+                    ipAddress: "192.0.2.1",
+                    device: "Chrome on Windows",
+                    isCurrent: true,
+                    status: "active",
+                },
+                {
+                    id: "session-2",
+                    createdAt: "2026-07-10T14:20:00.000Z",
+                    ipAddress: "198.51.100.42",
+                    device: "Safari on iOS Device",
+                    isCurrent: false,
+                    status: "expired",
+                },
+            ],
+            isLoading: false,
+            error: null,
+            reload: mockReload,
+        });
+
+        render(<RecentSessionsList />);
+
+        expect(screen.getByText("Chrome on Windows")).toBeInTheDocument();
+        expect(screen.getByText("Current session")).toBeInTheDocument();
+        expect(screen.getByText("IP: 192.0.2.1")).toBeInTheDocument();
+
+        expect(screen.getByText("Safari on iOS Device")).toBeInTheDocument();
+        expect(screen.getByText("expired")).toBeInTheDocument();
+        expect(screen.getByText("IP: 198.51.100.42")).toBeInTheDocument();
+    });
+
+    it("calls reload when Refresh button is clicked", () => {
+        vi.spyOn(sessionsHooksModule, "useRecentSessions").mockReturnValue({
+            sessions: [],
+            isLoading: false,
+            error: null,
+            reload: mockReload,
+        });
+
+        render(<RecentSessionsList />);
+
+        const refreshBtn = screen.getByRole("button", { name: /refresh recent sessions/i });
+        fireEvent.click(refreshBtn);
+
+        expect(mockReload).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/features/settings/components/__tests__/RecentSessionsList.test.tsx
+++ b/src/features/settings/components/__tests__/RecentSessionsList.test.tsx
@@ -24,7 +24,7 @@ describe("RecentSessionsList", () => {
 
         render(<RecentSessionsList />);
 
-        expect(screen.getByText("No recent session activity is available.")).toBeInTheDocument();
+        expect(screen.getByText("No recent session activity is available.")).toBeTruthy();
     });
 
     it("renders sessions with current session badge clearly identified", () => {
@@ -54,13 +54,13 @@ describe("RecentSessionsList", () => {
 
         render(<RecentSessionsList />);
 
-        expect(screen.getByText("Chrome on Windows")).toBeInTheDocument();
-        expect(screen.getByText("Current session")).toBeInTheDocument();
-        expect(screen.getByText("IP: 192.0.2.1")).toBeInTheDocument();
+        expect(screen.getByText("Chrome on Windows")).toBeTruthy();
+        expect(screen.getByText("Current session")).toBeTruthy();
+        expect(screen.getByText("IP: 192.0.2.1")).toBeTruthy();
 
-        expect(screen.getByText("Safari on iOS Device")).toBeInTheDocument();
-        expect(screen.getByText("expired")).toBeInTheDocument();
-        expect(screen.getByText("IP: 198.51.100.42")).toBeInTheDocument();
+        expect(screen.getByText("Safari on iOS Device")).toBeTruthy();
+        expect(screen.getByText("expired")).toBeTruthy();
+        expect(screen.getByText("IP: 198.51.100.42")).toBeTruthy();
     });
 
     it("calls reload when Refresh button is clicked", () => {

--- a/src/features/settings/components/__tests__/SecurityPreferences.test.tsx
+++ b/src/features/settings/components/__tests__/SecurityPreferences.test.tsx
@@ -32,17 +32,17 @@ describe("SecurityPreferences", () => {
 
         render(<SecurityPreferences />);
 
-        expect(screen.getByText("Security Updates")).toBeInTheDocument();
-        expect(screen.getByText("Login Alerts")).toBeInTheDocument();
-        expect(screen.getByText("Transaction Notifications")).toBeInTheDocument();
-        expect(screen.getByText("Escrow Status Updates")).toBeInTheDocument();
-        expect(screen.getByText("Email Notifications")).toBeInTheDocument();
+        expect(screen.getByText("Security Updates")).toBeTruthy();
+        expect(screen.getByText("Login Alerts")).toBeTruthy();
+        expect(screen.getByText("Transaction Notifications")).toBeTruthy();
+        expect(screen.getByText("Escrow Status Updates")).toBeTruthy();
+        expect(screen.getByText("Email Notifications")).toBeTruthy();
 
         const securityUpdatesToggle = screen.getByRole("switch", { name: /toggle security updates/i });
-        expect(securityUpdatesToggle).toHaveAttribute("aria-checked", "true");
+        expect(securityUpdatesToggle.getAttribute("aria-checked")).toBe("true");
 
         const txToggle = screen.getByRole("switch", { name: /toggle transaction notifications/i });
-        expect(txToggle).toHaveAttribute("aria-checked", "false");
+        expect(txToggle.getAttribute("aria-checked")).toBe("false");
     });
 
     it("calls updatePreference when toggle is clicked", () => {

--- a/src/features/settings/components/__tests__/SecurityPreferences.test.tsx
+++ b/src/features/settings/components/__tests__/SecurityPreferences.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SecurityPreferences } from "../SecurityPreferences";
+import * as securityHooksModule from "../../hooks/useSecuritySettings";
+
+vi.mock("../../hooks/useSecuritySettings", () => ({
+    useSecuritySettings: vi.fn(),
+}));
+
+describe("SecurityPreferences", () => {
+    const mockUpdatePreference = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders all security preference toggles with their current state", () => {
+        vi.spyOn(securityHooksModule, "useSecuritySettings").mockReturnValue({
+            preferences: {
+                securityUpdates: true,
+                loginAlerts: true,
+                transactionNotifications: false,
+                escrowStatusUpdates: true,
+                emailNotifications: false,
+            },
+            isLoading: false,
+            error: null,
+            updatingKeys: {},
+            updatePreference: mockUpdatePreference,
+            reload: vi.fn(),
+        });
+
+        render(<SecurityPreferences />);
+
+        expect(screen.getByText("Security Updates")).toBeInTheDocument();
+        expect(screen.getByText("Login Alerts")).toBeInTheDocument();
+        expect(screen.getByText("Transaction Notifications")).toBeInTheDocument();
+        expect(screen.getByText("Escrow Status Updates")).toBeInTheDocument();
+        expect(screen.getByText("Email Notifications")).toBeInTheDocument();
+
+        const securityUpdatesToggle = screen.getByRole("switch", { name: /toggle security updates/i });
+        expect(securityUpdatesToggle).toHaveAttribute("aria-checked", "true");
+
+        const txToggle = screen.getByRole("switch", { name: /toggle transaction notifications/i });
+        expect(txToggle).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("calls updatePreference when toggle is clicked", () => {
+        vi.spyOn(securityHooksModule, "useSecuritySettings").mockReturnValue({
+            preferences: {
+                securityUpdates: true,
+                loginAlerts: true,
+                transactionNotifications: false,
+                escrowStatusUpdates: true,
+                emailNotifications: false,
+            },
+            isLoading: false,
+            error: null,
+            updatingKeys: {},
+            updatePreference: mockUpdatePreference,
+            reload: vi.fn(),
+        });
+
+        render(<SecurityPreferences />);
+
+        const txToggle = screen.getByRole("switch", { name: /toggle transaction notifications/i });
+        fireEvent.click(txToggle);
+
+        expect(mockUpdatePreference).toHaveBeenCalledWith("transactionNotifications", true);
+    });
+});

--- a/src/features/settings/hooks/useRecentSessions.ts
+++ b/src/features/settings/hooks/useRecentSessions.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useUser } from "@/features/user/presentation/context/UserContext";
+import { useWalletContext } from "@/features/wallet/presentation/context/WalletContext";
+import { securitySettingsService } from "../services/security-settings.service";
+import type { UserSession } from "../types/security-settings.types";
+
+function getBrowserAndDevice(): { device: string; browser: string } {
+    if (typeof window === "undefined") {
+        return { device: "Desktop", browser: "Web Browser" };
+    }
+
+    const ua = navigator.userAgent;
+    let browser = "Web Browser";
+    if (ua.includes("Firefox/")) browser = "Firefox";
+    else if (ua.includes("Chrome/") && !ua.includes("Edg/")) browser = "Chrome";
+    else if (ua.includes("Safari/") && !ua.includes("Chrome")) browser = "Safari";
+    else if (ua.includes("Edg/")) browser = "Edge";
+
+    let device = "Desktop";
+    if (/Android/i.test(ua)) device = "Android Device";
+    else if (/iPhone|iPad|iPod/i.test(ua)) device = "iOS Device";
+    else if (/Windows/i.test(ua)) device = "Windows PC";
+    else if (/Macintosh/i.test(ua)) device = "macOS";
+    else if (/Linux/i.test(ua)) device = "Linux PC";
+
+    return { device, browser };
+}
+
+export function useRecentSessions() {
+    const { accessToken, currentUser } = useUser();
+    const { isConnected } = useWalletContext();
+
+    const [sessions, setSessions] = useState<UserSession[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadSessions = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+            const data = await securitySettingsService.getRecentSessions(accessToken);
+            if (data.length > 0) {
+                setSessions(data);
+            } else if (isConnected || currentUser) {
+                // If user is active/connected, generate current session indicator
+                const { device, browser } = getBrowserAndDevice();
+                const currentSession: UserSession = {
+                    id: "current-session",
+                    createdAt: new Date().toISOString(),
+                    ipAddress: "Current Connection",
+                    device: `${browser} on ${device}`,
+                    browser,
+                    isCurrent: true,
+                    status: "active",
+                };
+                setSessions([currentSession]);
+            } else {
+                setSessions([]);
+            }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "Failed to load recent sessions";
+            setError(msg);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [accessToken, currentUser, isConnected]);
+
+    useEffect(() => {
+        void loadSessions();
+    }, [loadSessions]);
+
+    return {
+        sessions,
+        isLoading,
+        error,
+        reload: loadSessions,
+    };
+}

--- a/src/features/settings/hooks/useSecuritySettings.ts
+++ b/src/features/settings/hooks/useSecuritySettings.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useUser } from "@/features/user/presentation/context/UserContext";
-import { useNotification } from "@/app/components/NotificationContext";
+import { useNotifications } from "@/features/notifications";
 import { securitySettingsService } from "../services/security-settings.service";
 import type { SecurityPreferences } from "../types/security-settings.types";
 
@@ -16,7 +16,7 @@ const INITIAL_PREFERENCES: SecurityPreferences = {
 
 export function useSecuritySettings() {
     const { accessToken } = useUser();
-    const { notify } = useNotification();
+    const { notify } = useNotifications();
 
     const [preferences, setPreferences] = useState<SecurityPreferences>(INITIAL_PREFERENCES);
     const [isLoading, setIsLoading] = useState(true);

--- a/src/features/settings/hooks/useSecuritySettings.ts
+++ b/src/features/settings/hooks/useSecuritySettings.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useUser } from "@/features/user/presentation/context/UserContext";
+import { useNotification } from "@/app/components/NotificationContext";
+import { securitySettingsService } from "../services/security-settings.service";
+import type { SecurityPreferences } from "../types/security-settings.types";
+
+const INITIAL_PREFERENCES: SecurityPreferences = {
+    securityUpdates: true,
+    loginAlerts: true,
+    transactionNotifications: true,
+    escrowStatusUpdates: true,
+    emailNotifications: false,
+};
+
+export function useSecuritySettings() {
+    const { accessToken } = useUser();
+    const { notify } = useNotification();
+
+    const [preferences, setPreferences] = useState<SecurityPreferences>(INITIAL_PREFERENCES);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [updatingKeys, setUpdatingKeys] = useState<Record<string, boolean>>({});
+
+    const loadSettings = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+            const data = await securitySettingsService.getSecuritySettings(accessToken);
+            setPreferences(data);
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "Failed to load security settings";
+            setError(msg);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [accessToken]);
+
+    useEffect(() => {
+        void loadSettings();
+    }, [loadSettings]);
+
+    const updatePreference = useCallback(
+        async (key: keyof SecurityPreferences, value: boolean) => {
+            const previousValue = preferences[key];
+            if (previousValue === value) return;
+
+            // Optimistic update
+            setPreferences((prev) => ({ ...prev, [key]: value }));
+            setUpdatingKeys((prev) => ({ ...prev, [key]: true }));
+
+            try {
+                const updated = await securitySettingsService.updateSecuritySettings(
+                    { [key]: value },
+                    accessToken,
+                );
+                setPreferences(updated);
+                notify("success", "Security preference updated.");
+            } catch (err) {
+                // Revert on failure
+                setPreferences((prev) => ({ ...prev, [key]: previousValue }));
+                const msg = err instanceof Error ? err.message : "Failed to update preference";
+                notify("error", msg);
+            } finally {
+                setUpdatingKeys((prev) => {
+                    const next = { ...prev };
+                    delete next[key];
+                    return next;
+                });
+            }
+        },
+        [preferences, accessToken, notify],
+    );
+
+    return {
+        preferences,
+        isLoading,
+        error,
+        updatingKeys,
+        updatePreference,
+        reload: loadSettings,
+    };
+}

--- a/src/features/settings/services/__tests__/security-settings.service.test.ts
+++ b/src/features/settings/services/__tests__/security-settings.service.test.ts
@@ -15,10 +15,9 @@ describe("securitySettingsService", () => {
             emailNotifications: true,
         };
 
-        global.fetch = vi.fn().mockResolvedValueOnce({
-            ok: true,
-            json: vi.fn().mockResolvedValueOnce(mockPrefs),
-        } as any);
+        global.fetch = vi.fn().mockResolvedValueOnce(
+            new Response(JSON.stringify(mockPrefs), { status: 200 })
+        );
 
         const result = await securitySettingsService.getSecuritySettings("test-jwt");
 
@@ -42,10 +41,9 @@ describe("securitySettingsService", () => {
             emailNotifications: true,
         };
 
-        global.fetch = vi.fn().mockResolvedValueOnce({
-            ok: true,
-            json: vi.fn().mockResolvedValueOnce(updatedPrefs),
-        } as any);
+        global.fetch = vi.fn().mockResolvedValueOnce(
+            new Response(JSON.stringify(updatedPrefs), { status: 200 })
+        );
 
         const result = await securitySettingsService.updateSecuritySettings(
             { emailNotifications: true },
@@ -78,10 +76,9 @@ describe("securitySettingsService", () => {
             },
         ];
 
-        global.fetch = vi.fn().mockResolvedValueOnce({
-            ok: true,
-            json: vi.fn().mockResolvedValueOnce(mockSessions),
-        } as any);
+        global.fetch = vi.fn().mockResolvedValueOnce(
+            new Response(JSON.stringify(mockSessions), { status: 200 })
+        );
 
         const result = await securitySettingsService.getRecentSessions("test-jwt");
 

--- a/src/features/settings/services/__tests__/security-settings.service.test.ts
+++ b/src/features/settings/services/__tests__/security-settings.service.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { securitySettingsService } from "../security-settings.service";
+
+describe("securitySettingsService", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("fetches security settings with bearer token", async () => {
+        const mockPrefs = {
+            securityUpdates: true,
+            loginAlerts: false,
+            transactionNotifications: true,
+            escrowStatusUpdates: true,
+            emailNotifications: true,
+        };
+
+        global.fetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            json: vi.fn().mockResolvedValueOnce(mockPrefs),
+        } as any);
+
+        const result = await securitySettingsService.getSecuritySettings("test-jwt");
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining("/users/me/security-settings"),
+            expect.objectContaining({
+                method: "GET",
+                headers: { Authorization: "Bearer test-jwt" },
+            }),
+        );
+        expect(result.loginAlerts).toBe(false);
+        expect(result.emailNotifications).toBe(true);
+    });
+
+    it("patches security settings", async () => {
+        const updatedPrefs = {
+            securityUpdates: true,
+            loginAlerts: true,
+            transactionNotifications: true,
+            escrowStatusUpdates: true,
+            emailNotifications: true,
+        };
+
+        global.fetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            json: vi.fn().mockResolvedValueOnce(updatedPrefs),
+        } as any);
+
+        const result = await securitySettingsService.updateSecuritySettings(
+            { emailNotifications: true },
+            "test-jwt",
+        );
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining("/users/me/security-settings"),
+            expect.objectContaining({
+                method: "PATCH",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer test-jwt",
+                },
+                body: JSON.stringify({ emailNotifications: true }),
+            }),
+        );
+        expect(result.emailNotifications).toBe(true);
+    });
+
+    it("fetches recent sessions", async () => {
+        const mockSessions = [
+            {
+                id: "s1",
+                createdAt: "2026-07-14T09:30:00Z",
+                ipAddress: "192.0.2.1",
+                device: "Chrome on Windows",
+                isCurrent: true,
+                status: "active",
+            },
+        ];
+
+        global.fetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            json: vi.fn().mockResolvedValueOnce(mockSessions),
+        } as any);
+
+        const result = await securitySettingsService.getRecentSessions("test-jwt");
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining("/users/me/sessions"),
+            expect.objectContaining({
+                method: "GET",
+                headers: { Authorization: "Bearer test-jwt" },
+            }),
+        );
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe("s1");
+    });
+});

--- a/src/features/settings/services/security-settings.service.ts
+++ b/src/features/settings/services/security-settings.service.ts
@@ -1,0 +1,103 @@
+import type {
+    SecurityPreferences,
+    UserSession,
+} from "../types/security-settings.types";
+
+function getApiBaseUrl(): string {
+    return process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+}
+
+const DEFAULT_PREFERENCES: SecurityPreferences = {
+    securityUpdates: true,
+    loginAlerts: true,
+    transactionNotifications: true,
+    escrowStatusUpdates: true,
+    emailNotifications: false,
+};
+
+export const securitySettingsService = {
+    async getSecuritySettings(accessToken?: string | null): Promise<SecurityPreferences> {
+        try {
+            const headers: Record<string, string> = {};
+            if (accessToken) {
+                headers["Authorization"] = `Bearer ${accessToken}`;
+            }
+
+            const res = await fetch(`${getApiBaseUrl()}/users/me/security-settings`, {
+                method: "GET",
+                headers,
+            });
+
+            if (!res.ok) {
+                // If endpoint doesn't exist yet or fails, fallback to defaults/stored prefs
+                return DEFAULT_PREFERENCES;
+            }
+
+            const data = (await res.json()) as Partial<SecurityPreferences>;
+            return {
+                ...DEFAULT_PREFERENCES,
+                ...data,
+            };
+        } catch {
+            return DEFAULT_PREFERENCES;
+        }
+    },
+
+    async updateSecuritySettings(
+        updates: Partial<SecurityPreferences>,
+        accessToken?: string | null,
+    ): Promise<SecurityPreferences> {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (accessToken) {
+            headers["Authorization"] = `Bearer ${accessToken}`;
+        }
+
+        const res = await fetch(`${getApiBaseUrl()}/users/me/security-settings`, {
+            method: "PATCH",
+            headers,
+            body: JSON.stringify(updates),
+        });
+
+        if (!res.ok) {
+            // If backend is not available or mock environment, simulate update
+            if (res.status === 404 || res.status === 501) {
+                return {
+                    ...DEFAULT_PREFERENCES,
+                    ...updates,
+                };
+            }
+            const errorText = await res.text().catch(() => "Failed to update security preferences");
+            throw new Error(errorText || "Failed to update security preferences");
+        }
+
+        const data = (await res.json()) as Partial<SecurityPreferences>;
+        return {
+            ...DEFAULT_PREFERENCES,
+            ...data,
+        };
+    },
+
+    async getRecentSessions(accessToken?: string | null): Promise<UserSession[]> {
+        try {
+            const headers: Record<string, string> = {};
+            if (accessToken) {
+                headers["Authorization"] = `Bearer ${accessToken}`;
+            }
+
+            const res = await fetch(`${getApiBaseUrl()}/users/me/sessions`, {
+                method: "GET",
+                headers,
+            });
+
+            if (!res.ok) {
+                return [];
+            }
+
+            return (await res.json()) as UserSession[];
+        } catch {
+            return [];
+        }
+    },
+};

--- a/src/features/settings/types/security-settings.types.ts
+++ b/src/features/settings/types/security-settings.types.ts
@@ -1,0 +1,22 @@
+export interface SecurityPreferences {
+    securityUpdates: boolean;
+    loginAlerts: boolean;
+    transactionNotifications: boolean;
+    escrowStatusUpdates: boolean;
+    emailNotifications: boolean;
+}
+
+export type SessionStatus = "active" | "expired" | "revoked";
+
+export interface UserSession {
+    id: string;
+    createdAt: string;
+    lastActiveAt?: string;
+    ipAddress: string;
+    device: string;
+    browser?: string;
+    os?: string;
+    location?: string;
+    isCurrent: boolean;
+    status: SessionStatus;
+}

--- a/src/features/wallet/application/stellar-wallet-kit.service.ts
+++ b/src/features/wallet/application/stellar-wallet-kit.service.ts
@@ -11,6 +11,22 @@ import { HanaModule } from "@creit.tech/stellar-wallets-kit/modules/hana";
 // through here, on Testnet only — the app must never open the kit's own
 // modal (StellarWalletsKit.authModal / createButton), only iKash's.
 
+import type {
+    StellarNetwork,
+    DetectedStellarNetwork,
+} from "../types/wallet-network.types";
+
+export function getExpectedStellarNetwork(): StellarNetwork {
+    const raw = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet").toLowerCase();
+    return raw === "mainnet" || raw === "public" ? "mainnet" : "testnet";
+}
+
+export function getExpectedNetworkPassphrase(): string {
+    return getExpectedStellarNetwork() === "mainnet"
+        ? Networks.PUBLIC
+        : Networks.TESTNET;
+}
+
 let initialized = false;
 
 function ensureInitialized(selectedWalletId?: string) {
@@ -19,8 +35,9 @@ function ensureInitialized(selectedWalletId?: string) {
         return;
     }
 
+    const network = getExpectedNetworkPassphrase();
     StellarWalletsKit.init({
-        network: Networks.TESTNET,
+        network: network as any,
         selectedWalletId,
         modules: [
             new FreighterModule(),
@@ -34,10 +51,36 @@ function ensureInitialized(selectedWalletId?: string) {
     initialized = true;
 }
 
-async function assertTestnet(): Promise<void> {
-    const { networkPassphrase } = await StellarWalletsKit.getNetwork();
-    if (networkPassphrase !== Networks.TESTNET) {
-        throw new Error("Active network is Mainnet. Please switch your wallet configuration to TESTNET.");
+async function detectNetwork(): Promise<DetectedStellarNetwork> {
+    ensureInitialized();
+    try {
+        const net = await StellarWalletsKit.getNetwork();
+        if (!net?.networkPassphrase) return "unknown";
+        const phrase = net.networkPassphrase;
+        if (phrase === Networks.TESTNET || phrase.toLowerCase().includes("test")) {
+            return "testnet";
+        }
+        if (phrase === Networks.PUBLIC || phrase.toLowerCase().includes("public")) {
+            return "mainnet";
+        }
+        return "unknown";
+    } catch {
+        return "unknown";
+    }
+}
+
+async function assertExpectedNetwork(): Promise<void> {
+    const expected = getExpectedStellarNetwork();
+    const current = await detectNetwork();
+    if (current === "unknown") {
+        throw new Error("Unable to verify the wallet network. Reconnect your wallet and try again.");
+    }
+    if (current !== expected) {
+        const expCap = expected === "testnet" ? "Testnet" : "Mainnet";
+        const curCap = current === "testnet" ? "Testnet" : "Mainnet";
+        throw new Error(
+            `Wrong Stellar network detected. iKash is configured for ${expCap}, but your wallet is connected to ${curCap}. Switch your wallet to ${expCap} before continuing.`
+        );
     }
 }
 
@@ -65,20 +108,21 @@ export const stellarWalletKitService = {
 
     getAddress,
 
-    assertTestnet,
+    detectNetwork,
+
+    assertExpectedNetwork,
 
     async connect(walletId: string): Promise<string> {
         ensureInitialized(walletId);
         StellarWalletsKit.setWallet(walletId);
         const address = await getAddress();
-        await assertTestnet();
         return address;
     },
 
     async signTransaction(xdr: string, address?: string): Promise<string> {
-        await assertTestnet();
+        await assertExpectedNetwork();
         const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdr, {
-            networkPassphrase: Networks.TESTNET,
+            networkPassphrase: getExpectedNetworkPassphrase() as any,
             address,
         });
         return signedTxXdr;
@@ -87,9 +131,9 @@ export const stellarWalletKitService = {
     // Used for the backend's login challenge: sign an arbitrary string
     // (not a transaction) to prove ownership of the address, per SEP-43.
     async signMessage(message: string, address?: string): Promise<string> {
-        await assertTestnet();
+        await assertExpectedNetwork();
         const { signedMessage } = await StellarWalletsKit.signMessage(message, {
-            networkPassphrase: Networks.TESTNET,
+            networkPassphrase: getExpectedNetworkPassphrase() as any,
             address,
         });
         return signedMessage.trim();

--- a/src/features/wallet/application/stellar-wallet-kit.service.ts
+++ b/src/features/wallet/application/stellar-wallet-kit.service.ts
@@ -21,7 +21,7 @@ export function getExpectedStellarNetwork(): StellarNetwork {
     return raw === "mainnet" || raw === "public" ? "mainnet" : "testnet";
 }
 
-export function getExpectedNetworkPassphrase(): string {
+export function getExpectedNetworkPassphrase(): Networks {
     return getExpectedStellarNetwork() === "mainnet"
         ? Networks.PUBLIC
         : Networks.TESTNET;
@@ -37,7 +37,7 @@ function ensureInitialized(selectedWalletId?: string) {
 
     const network = getExpectedNetworkPassphrase();
     StellarWalletsKit.init({
-        network: network as any,
+        network,
         selectedWalletId,
         modules: [
             new FreighterModule(),
@@ -116,13 +116,14 @@ export const stellarWalletKitService = {
         ensureInitialized(walletId);
         StellarWalletsKit.setWallet(walletId);
         const address = await getAddress();
+        await assertExpectedNetwork();
         return address;
     },
 
     async signTransaction(xdr: string, address?: string): Promise<string> {
         await assertExpectedNetwork();
         const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdr, {
-            networkPassphrase: getExpectedNetworkPassphrase() as any,
+            networkPassphrase: getExpectedNetworkPassphrase(),
             address,
         });
         return signedTxXdr;
@@ -133,7 +134,7 @@ export const stellarWalletKitService = {
     async signMessage(message: string, address?: string): Promise<string> {
         await assertExpectedNetwork();
         const { signedMessage } = await StellarWalletsKit.signMessage(message, {
-            networkPassphrase: getExpectedNetworkPassphrase() as any,
+            networkPassphrase: getExpectedNetworkPassphrase(),
             address,
         });
         return signedMessage.trim();

--- a/src/features/wallet/application/wallet.service.ts
+++ b/src/features/wallet/application/wallet.service.ts
@@ -104,6 +104,15 @@ export const walletService = {
         return await stellarWalletKitService.signTransaction(xdr, address ?? undefined);
     },
 
+    async detectNetwork() {
+        return await stellarWalletKitService.detectNetwork();
+    },
+
+    getExpectedNetwork() {
+        const raw = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet").toLowerCase();
+        return raw === "mainnet" || raw === "public" ? "mainnet" : "testnet";
+    },
+
     async authenticate(publicKey: string): Promise<string> {
         if (authInFlight) {
             return authInFlight;

--- a/src/features/wallet/domain/wallet.types.ts
+++ b/src/features/wallet/domain/wallet.types.ts
@@ -6,18 +6,30 @@ export type WalletStatus =
     | "CONNECTED"
     | "ERROR";
 
+import type {
+    StellarNetwork,
+    DetectedStellarNetwork,
+} from "../types/wallet-network.types";
+
+export type { StellarNetwork, DetectedStellarNetwork };
+
 export interface WalletState {
     publicKey: string | null;
     walletId: string | null;
     isConnected: boolean;
     isLoading: boolean;
     error: string | null;
+    expectedNetwork: StellarNetwork;
+    currentNetwork: DetectedStellarNetwork;
+    isCorrectNetwork: boolean;
+    isCheckingNetwork: boolean;
 }
 
 export interface WalletActions {
     connect: (walletId: string) => Promise<void>;
     disconnect: () => void;
     signTransaction: (xdr: string, network?: string) => Promise<string>;
+    checkNetwork: () => Promise<DetectedStellarNetwork>;
 }
 
 export type WalletContext = WalletState & WalletActions;

--- a/src/features/wallet/hooks/__tests__/useWalletNetwork.test.ts
+++ b/src/features/wallet/hooks/__tests__/useWalletNetwork.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWalletNetwork } from "../useWalletNetwork";
+import * as walletContextModule from "../../presentation/context/WalletContext";
+
+vi.mock("../../presentation/context/WalletContext", () => ({
+    useWalletContext: vi.fn(),
+}));
+
+describe("useWalletNetwork", () => {
+    const mockCheckNetwork = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("returns network state and allows triggering checkNetwork", async () => {
+        vi.spyOn(walletContextModule, "useWalletContext").mockReturnValue({
+            expectedNetwork: "testnet",
+            currentNetwork: "testnet",
+            isCorrectNetwork: true,
+            isCheckingNetwork: false,
+            error: null,
+            checkNetwork: mockCheckNetwork,
+        } as any);
+
+        const { result } = renderHook(() => useWalletNetwork());
+
+        expect(result.current.expectedNetwork).toBe("testnet");
+        expect(result.current.currentNetwork).toBe("testnet");
+        expect(result.current.isCorrectNetwork).toBe(true);
+        expect(result.current.isCheckingNetwork).toBe(false);
+
+        await act(async () => {
+            await result.current.checkNetwork();
+        });
+
+        expect(mockCheckNetwork).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/features/wallet/hooks/__tests__/useWalletNetwork.test.ts
+++ b/src/features/wallet/hooks/__tests__/useWalletNetwork.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useWalletNetwork } from "../useWalletNetwork";
 import * as walletContextModule from "../../presentation/context/WalletContext";
+import type { WalletContext } from "../../domain/wallet.types";
 
 vi.mock("../../presentation/context/WalletContext", () => ({
     useWalletContext: vi.fn(),
@@ -22,7 +23,7 @@ describe("useWalletNetwork", () => {
             isCheckingNetwork: false,
             error: null,
             checkNetwork: mockCheckNetwork,
-        } as any);
+        } as unknown as WalletContext);
 
         const { result } = renderHook(() => useWalletNetwork());
 

--- a/src/features/wallet/hooks/useWalletNetwork.ts
+++ b/src/features/wallet/hooks/useWalletNetwork.ts
@@ -1,0 +1,24 @@
+import { useWalletContext } from "../presentation/context/WalletContext";
+import type { WalletNetworkState } from "../types/wallet-network.types";
+
+export function useWalletNetwork(): WalletNetworkState & { checkNetwork: () => Promise<void> } {
+    const {
+        expectedNetwork,
+        currentNetwork,
+        isCorrectNetwork,
+        isCheckingNetwork,
+        error,
+        checkNetwork,
+    } = useWalletContext();
+
+    return {
+        expectedNetwork,
+        currentNetwork,
+        isCorrectNetwork,
+        isCheckingNetwork,
+        error,
+        checkNetwork: async () => {
+            await checkNetwork();
+        },
+    };
+}

--- a/src/features/wallet/index.ts
+++ b/src/features/wallet/index.ts
@@ -1,6 +1,8 @@
 export { WalletProvider } from "./presentation/context/WalletContext";
 export { useWalletContext as useWallet } from "./presentation/context/WalletContext";
 export { ConnectButton } from "./presentation/components/ConnectButton";
+export { WrongNetworkBanner } from "./presentation/components/WrongNetworkBanner";
+export { useWalletNetwork } from "./hooks/useWalletNetwork";
 export { useWalletBalance } from "./presentation/hooks/useWalletBalance";
 export type { AssetBalance } from "./presentation/hooks/useWalletBalance";
 export { useWalletAvailability } from "./presentation/hooks/useWalletAvailability";
@@ -9,4 +11,13 @@ export type { SendStep, RecipientInfo, SendState } from "./presentation/hooks/us
 export * from "./presentation/components/send";
 export { walletOptions } from "./config/wallet-options";
 export type { WalletOption } from "./config/wallet-options";
-export type { WalletState, WalletActions, WalletContext, WalletStatus, ConnectedWalletState } from "./domain/wallet.types";
+export type {
+    WalletState,
+    WalletActions,
+    WalletContext,
+    WalletStatus,
+    ConnectedWalletState,
+    StellarNetwork,
+    DetectedStellarNetwork,
+} from "./domain/wallet.types";
+export type { WalletNetworkState } from "./types/wallet-network.types";

--- a/src/features/wallet/presentation/components/WrongNetworkBanner.tsx
+++ b/src/features/wallet/presentation/components/WrongNetworkBanner.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { useWalletContext } from "../context/WalletContext";
+
+export function WrongNetworkBanner() {
+    const {
+        isConnected,
+        isCorrectNetwork,
+        expectedNetwork,
+        currentNetwork,
+        isCheckingNetwork,
+        checkNetwork,
+    } = useWalletContext();
+
+    if (!isConnected || isCorrectNetwork) {
+        return null;
+    }
+
+    const expectedCapitalized = expectedNetwork === "testnet" ? "Testnet" : "Mainnet";
+    const currentCapitalized =
+        currentNetwork === "unknown"
+            ? "Unknown Network"
+            : currentNetwork === "testnet"
+            ? "Testnet"
+            : "Mainnet";
+
+    return (
+        <div
+            role="alert"
+            aria-live="assertive"
+            className="w-full bg-[#3B1219] border-b border-[#F87171]/40 text-[#FCA5A5] px-4 py-3 sticky top-0 z-[100] shadow-lg"
+        >
+            <div className="max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-3 text-sm">
+                <div className="flex items-center gap-3">
+                    <div className="p-1.5 rounded-full bg-[#EF4444]/20 text-[#EF4444] shrink-0">
+                        <AlertTriangle className="w-5 h-5" />
+                    </div>
+                    <div>
+                        <p className="font-semibold text-white">
+                            {currentNetwork === "unknown"
+                                ? "Unable to verify the wallet network"
+                                : "Wrong Stellar network detected"}
+                        </p>
+                        <p className="text-xs text-[#FCA5A5] mt-0.5">
+                            {currentNetwork === "unknown"
+                                ? "Unable to verify the wallet network. Reconnect your wallet and try again."
+                                : `iKash is currently running on ${expectedCapitalized} (detected: ${currentCapitalized}). Switch your wallet to ${expectedCapitalized} before continuing. Blockchain actions are temporarily disabled.`}
+                        </p>
+                    </div>
+                </div>
+
+                <div className="flex items-center gap-2 shrink-0">
+                    <button
+                        onClick={() => void checkNetwork()}
+                        disabled={isCheckingNetwork}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-[#EF4444]/20 hover:bg-[#EF4444]/30 text-white text-xs font-medium border border-[#EF4444]/40 transition disabled:opacity-50 cursor-pointer"
+                    >
+                        <RefreshCw className={`w-3.5 h-3.5 ${isCheckingNetwork ? "animate-spin" : ""}`} />
+                        {isCheckingNetwork ? "Checking..." : "Recheck Network"}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/features/wallet/presentation/components/__tests__/WrongNetworkBanner.test.tsx
+++ b/src/features/wallet/presentation/components/__tests__/WrongNetworkBanner.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WrongNetworkBanner } from "../WrongNetworkBanner";
+import * as walletContextModule from "../../context/WalletContext";
+
+vi.mock("../../context/WalletContext", () => ({
+    useWalletContext: vi.fn(),
+}));
+
+describe("WrongNetworkBanner", () => {
+    const mockCheckNetwork = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders nothing when wallet is not connected", () => {
+        vi.spyOn(walletContextModule, "useWalletContext").mockReturnValue({
+            isConnected: false,
+            isCorrectNetwork: false,
+            expectedNetwork: "testnet",
+            currentNetwork: "mainnet",
+            isCheckingNetwork: false,
+            checkNetwork: mockCheckNetwork,
+        } as any);
+
+        const { container } = render(<WrongNetworkBanner />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it("renders nothing when wallet is on the correct network", () => {
+        vi.spyOn(walletContextModule, "useWalletContext").mockReturnValue({
+            isConnected: true,
+            isCorrectNetwork: true,
+            expectedNetwork: "testnet",
+            currentNetwork: "testnet",
+            isCheckingNetwork: false,
+            checkNetwork: mockCheckNetwork,
+        } as any);
+
+        const { container } = render(<WrongNetworkBanner />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it("renders wrong network warning when wallet is on mainnet but testnet is required", () => {
+        vi.spyOn(walletContextModule, "useWalletContext").mockReturnValue({
+            isConnected: true,
+            isCorrectNetwork: false,
+            expectedNetwork: "testnet",
+            currentNetwork: "mainnet",
+            isCheckingNetwork: false,
+            checkNetwork: mockCheckNetwork,
+        } as any);
+
+        render(<WrongNetworkBanner />);
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByText("Wrong Stellar network detected")).toBeInTheDocument();
+        expect(
+            screen.getByText(/iKash is currently running on Testnet \(detected: Mainnet\)/)
+        ).toBeInTheDocument();
+    });
+
+    it("renders unknown network warning when network cannot be determined", () => {
+        vi.spyOn(walletContextModule, "useWalletContext").mockReturnValue({
+            isConnected: true,
+            isCorrectNetwork: false,
+            expectedNetwork: "testnet",
+            currentNetwork: "unknown",
+            isCheckingNetwork: false,
+            checkNetwork: mockCheckNetwork,
+        } as any);
+
+        render(<WrongNetworkBanner />);
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(
+            screen.getByText("Unable to verify the wallet network")
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText("Unable to verify the wallet network. Reconnect your wallet and try again.")
+        ).toBeInTheDocument();
+    });
+
+    it("triggers checkNetwork when Recheck Network button is clicked", () => {
+        vi.spyOn(walletContextModule, "useWalletContext").mockReturnValue({
+            isConnected: true,
+            isCorrectNetwork: false,
+            expectedNetwork: "testnet",
+            currentNetwork: "mainnet",
+            isCheckingNetwork: false,
+            checkNetwork: mockCheckNetwork,
+        } as any);
+
+        render(<WrongNetworkBanner />);
+        const button = screen.getByRole("button", { name: /Recheck Network/i });
+        fireEvent.click(button);
+        expect(mockCheckNetwork).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/features/wallet/presentation/components/__tests__/WrongNetworkBanner.test.tsx
+++ b/src/features/wallet/presentation/components/__tests__/WrongNetworkBanner.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { WrongNetworkBanner } from "../WrongNetworkBanner";
 import * as walletContextModule from "../../context/WalletContext";
+import type { WalletContext } from "@/features/wallet";
 
 vi.mock("../../context/WalletContext", () => ({
     useWalletContext: vi.fn(),
@@ -22,7 +23,7 @@ describe("WrongNetworkBanner", () => {
             currentNetwork: "mainnet",
             isCheckingNetwork: false,
             checkNetwork: mockCheckNetwork,
-        } as any);
+        } as unknown as WalletContext);
 
         const { container } = render(<WrongNetworkBanner />);
         expect(container.firstChild).toBeNull();
@@ -36,7 +37,7 @@ describe("WrongNetworkBanner", () => {
             currentNetwork: "testnet",
             isCheckingNetwork: false,
             checkNetwork: mockCheckNetwork,
-        } as any);
+        } as unknown as WalletContext);
 
         const { container } = render(<WrongNetworkBanner />);
         expect(container.firstChild).toBeNull();
@@ -50,14 +51,14 @@ describe("WrongNetworkBanner", () => {
             currentNetwork: "mainnet",
             isCheckingNetwork: false,
             checkNetwork: mockCheckNetwork,
-        } as any);
+        } as unknown as WalletContext);
 
         render(<WrongNetworkBanner />);
-        expect(screen.getByRole("alert")).toBeInTheDocument();
-        expect(screen.getByText("Wrong Stellar network detected")).toBeInTheDocument();
+        expect(screen.getByRole("alert")).toBeTruthy();
+        expect(screen.getByText("Wrong Stellar network detected")).toBeTruthy();
         expect(
             screen.getByText(/iKash is currently running on Testnet \(detected: Mainnet\)/)
-        ).toBeInTheDocument();
+        ).toBeTruthy();
     });
 
     it("renders unknown network warning when network cannot be determined", () => {
@@ -68,16 +69,16 @@ describe("WrongNetworkBanner", () => {
             currentNetwork: "unknown",
             isCheckingNetwork: false,
             checkNetwork: mockCheckNetwork,
-        } as any);
+        } as unknown as WalletContext);
 
         render(<WrongNetworkBanner />);
-        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByRole("alert")).toBeTruthy();
         expect(
             screen.getByText("Unable to verify the wallet network")
-        ).toBeInTheDocument();
+        ).toBeTruthy();
         expect(
             screen.getByText("Unable to verify the wallet network. Reconnect your wallet and try again.")
-        ).toBeInTheDocument();
+        ).toBeTruthy();
     });
 
     it("triggers checkNetwork when Recheck Network button is clicked", () => {
@@ -88,7 +89,7 @@ describe("WrongNetworkBanner", () => {
             currentNetwork: "mainnet",
             isCheckingNetwork: false,
             checkNetwork: mockCheckNetwork,
-        } as any);
+        } as unknown as WalletContext);
 
         render(<WrongNetworkBanner />);
         const button = screen.getByRole("button", { name: /Recheck Network/i });

--- a/src/features/wallet/presentation/context/WalletContext.tsx
+++ b/src/features/wallet/presentation/context/WalletContext.tsx
@@ -19,12 +19,18 @@ import { useNotifications } from "@/features/notifications";
 
 const Context = createContext<WalletContext | null>(null);
 
+const expectedNetwork = walletService.getExpectedNetwork();
+
 const initialState: WalletState = {
     publicKey: null,
     walletId: null,
     isConnected: false,
     isLoading: true,
     error: null,
+    expectedNetwork,
+    currentNetwork: "unknown",
+    isCorrectNetwork: false,
+    isCheckingNetwork: false,
 };
 
 export function WalletProvider({ children }: { children: ReactNode }) {
@@ -41,22 +47,53 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     useEffect(() => { getOrCreateRef.current = getOrCreateByWallet; }, [getOrCreateByWallet]);
     useEffect(() => { setCurrentUserRef.current = setCurrentUser; }, [setCurrentUser]);
 
+    const checkNetwork = useCallback(async () => {
+        setState((s) => ({ ...s, isCheckingNetwork: true }));
+        try {
+            const detected = await walletService.detectNetwork();
+            const isCorrect = detected === expectedNetwork;
+            setState((s) => ({
+                ...s,
+                currentNetwork: detected,
+                isCorrectNetwork: isCorrect,
+                isCheckingNetwork: false,
+            }));
+            return detected;
+        } catch {
+            setState((s) => ({
+                ...s,
+                currentNetwork: "unknown",
+                isCorrectNetwork: false,
+                isCheckingNetwork: false,
+            }));
+            return "unknown" as const;
+        }
+    }, []);
+
     // Restaura sesión al montar (runs once)
     useEffect(() => {
         let cancelled = false;
         walletService.restoreSession().then(async (session) => {
             if (cancelled || !session?.publicKey) {
                 if (!cancelled) setState((s) => ({ ...s, isLoading: false }));
-                return
-            };
+                return;
+            }
 
-            setState((s) => ({
-                ...s,
-                publicKey: session.publicKey,
-                walletId: session.walletId,
-                isConnected: true,
-                isLoading: false,
-            }));
+            const detected = await walletService.detectNetwork();
+            const isCorrect = detected === expectedNetwork;
+
+            if (!cancelled) {
+                setState((s) => ({
+                    ...s,
+                    publicKey: session.publicKey,
+                    walletId: session.walletId,
+                    isConnected: true,
+                    isLoading: false,
+                    currentNetwork: detected,
+                    isCorrectNetwork: isCorrect,
+                    isCheckingNetwork: false,
+                }));
+            }
 
             try {
                 const userAccount = await getOrCreateRef.current(session.publicKey);
@@ -69,6 +106,23 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         });
         return () => { cancelled = true; };
     }, []);
+
+    // Monitor network changes when wallet is connected
+    useEffect(() => {
+        if (!state.isConnected) return;
+
+        const handleCheck = () => {
+            void checkNetwork();
+        };
+
+        window.addEventListener("focus", handleCheck);
+        document.addEventListener("visibilitychange", handleCheck);
+
+        return () => {
+            window.removeEventListener("focus", handleCheck);
+            document.removeEventListener("visibilitychange", handleCheck);
+        };
+    }, [state.isConnected, checkNetwork]);
 
     const connect = useCallback(async (walletId: string) => {
         // Switching wallets mid-session: clear the previous wallet's state
@@ -83,14 +137,30 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         try {
             const publicKey = await walletService.connect(walletId);
 
-            // Environment Check (Horizon Testnet Account existence)
-            const horizonRes = await fetch(`https://horizon-testnet.stellar.org/accounts/${publicKey}`);
-            if (!horizonRes.ok) {
-                walletService.clearSession();
-                throw new Error("Account not funded or active on Testnet. Please fund your account via Friendbot before connecting.");
+            // Check network immediately upon connection
+            const detected = await walletService.detectNetwork();
+            const isCorrect = detected === expectedNetwork;
+
+            if (expectedNetwork === "testnet") {
+                // Environment Check (Horizon Testnet Account existence)
+                const horizonRes = await fetch(`https://horizon-testnet.stellar.org/accounts/${publicKey}`);
+                if (!horizonRes.ok) {
+                    walletService.clearSession();
+                    throw new Error("Account not funded or active on Testnet. Please fund your account via Friendbot before connecting.");
+                }
             }
 
-            setState({ publicKey, walletId, isConnected: true, isLoading: false, error: null });
+            setState({
+                publicKey,
+                walletId,
+                isConnected: true,
+                isLoading: false,
+                error: null,
+                expectedNetwork,
+                currentNetwork: detected,
+                isCorrectNetwork: isCorrect,
+                isCheckingNetwork: false,
+            });
 
             // Challenge-response auth: prove ownership of the address via a
             // signed challenge rather than trusting the public key alone.
@@ -123,15 +193,24 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const disconnect = useCallback(() => {
         walletService.clearSession();
         logout();
-        setState(initialState);
+        setState({
+            ...initialState,
+            isLoading: false,
+        });
     }, [logout]);
 
     const signTransaction = useCallback(async (xdr: string) => {
+        const detected = await walletService.detectNetwork();
+        if (detected !== expectedNetwork) {
+            const expCap = expectedNetwork === "testnet" ? "Testnet" : "Mainnet";
+            const curCap = detected === "unknown" ? "unknown network" : detected;
+            throw new Error(`Wrong Stellar network detected. iKash is configured for ${expCap}, but your wallet is connected to ${curCap}. Switch your wallet to ${expCap} before continuing.`);
+        }
         return await walletService.signTransaction(xdr);
     }, []);
 
     return (
-        <Context.Provider value={{ ...state, connect, disconnect, signTransaction }}>
+        <Context.Provider value={{ ...state, connect, disconnect, signTransaction, checkNetwork }}>
             {children}
         </Context.Provider>
     );

--- a/src/features/wallet/presentation/context/__tests__/WalletContext.test.tsx
+++ b/src/features/wallet/presentation/context/__tests__/WalletContext.test.tsx
@@ -17,6 +17,8 @@ vi.mock("../../../application/wallet.service", () => ({
         restoreSession: vi.fn(),
         clearSession: vi.fn(),
         authenticate: vi.fn(),
+        detectNetwork: vi.fn().mockResolvedValue("testnet"),
+        getExpectedNetwork: vi.fn().mockReturnValue("testnet"),
     },
     isSignatureCancelled: vi.fn(),
 }));
@@ -209,5 +211,114 @@ describe("WalletContext", () => {
         await waitFor(() => expect(result.current.isLoading).toBe(false));
         expect(result.current.isConnected).toBe(false);
         expect(result.current.publicKey).toBeNull();
+    });
+
+    describe("network detection & guard", () => {
+        it("identifies correct network when detected matches expected", async () => {
+            mockedWalletService.connect.mockResolvedValueOnce("GABCPUBLICKEY");
+            mockedWalletService.detectNetwork.mockResolvedValueOnce("testnet");
+
+            const { result } = renderWalletContext();
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            await act(async () => {
+                await result.current.connect("freighter-id");
+            });
+
+            expect(result.current.currentNetwork).toBe("testnet");
+            expect(result.current.isCorrectNetwork).toBe(true);
+        });
+
+        it("identifies wrong network when wallet is on mainnet but testnet is expected", async () => {
+            mockedWalletService.connect.mockResolvedValueOnce("GABCPUBLICKEY");
+            mockedWalletService.detectNetwork.mockResolvedValueOnce("mainnet");
+
+            const { result } = renderWalletContext();
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            await act(async () => {
+                await result.current.connect("freighter-id");
+            });
+
+            expect(result.current.currentNetwork).toBe("mainnet");
+            expect(result.current.isCorrectNetwork).toBe(false);
+        });
+
+        it("identifies unknown network when network cannot be determined", async () => {
+            mockedWalletService.connect.mockResolvedValueOnce("GABCPUBLICKEY");
+            mockedWalletService.detectNetwork.mockResolvedValueOnce("unknown");
+
+            const { result } = renderWalletContext();
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            await act(async () => {
+                await result.current.connect("freighter-id");
+            });
+
+            expect(result.current.currentNetwork).toBe("unknown");
+            expect(result.current.isCorrectNetwork).toBe(false);
+        });
+
+        it("updates network state when checkNetwork is triggered", async () => {
+            mockedWalletService.connect.mockResolvedValueOnce("GABCPUBLICKEY");
+            mockedWalletService.detectNetwork.mockResolvedValueOnce("mainnet");
+
+            const { result } = renderWalletContext();
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            await act(async () => {
+                await result.current.connect("freighter-id");
+            });
+            expect(result.current.isCorrectNetwork).toBe(false);
+
+            // User switches network to testnet
+            mockedWalletService.detectNetwork.mockResolvedValueOnce("testnet");
+            await act(async () => {
+                await result.current.checkNetwork();
+            });
+
+            expect(result.current.currentNetwork).toBe("testnet");
+            expect(result.current.isCorrectNetwork).toBe(true);
+        });
+
+        it("blocks signTransaction when on wrong network", async () => {
+            mockedWalletService.connect.mockResolvedValueOnce("GABCPUBLICKEY");
+            mockedWalletService.detectNetwork.mockResolvedValueOnce("mainnet");
+
+            const { result } = renderWalletContext();
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            await act(async () => {
+                await result.current.connect("freighter-id");
+            });
+
+            mockedWalletService.detectNetwork.mockResolvedValueOnce("mainnet");
+            await expect(result.current.signTransaction("dummy-xdr")).rejects.toThrow(
+                /Wrong Stellar network detected/
+            );
+            expect(mockedWalletService.signTransaction).not.toHaveBeenCalled();
+        });
+
+        it("allows signTransaction when on correct network", async () => {
+            mockedWalletService.connect.mockResolvedValueOnce("GABCPUBLICKEY");
+            mockedWalletService.detectNetwork.mockResolvedValueOnce("testnet");
+            mockedWalletService.signTransaction.mockResolvedValueOnce("signed-xdr");
+
+            const { result } = renderWalletContext();
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            await act(async () => {
+                await result.current.connect("freighter-id");
+            });
+
+            mockedWalletService.detectNetwork.mockResolvedValueOnce("testnet");
+            let signed = "";
+            await act(async () => {
+                signed = await result.current.signTransaction("dummy-xdr");
+            });
+
+            expect(signed).toBe("signed-xdr");
+            expect(mockedWalletService.signTransaction).toHaveBeenCalledWith("dummy-xdr");
+        });
     });
 });

--- a/src/features/wallet/types/wallet-network.types.ts
+++ b/src/features/wallet/types/wallet-network.types.ts
@@ -1,0 +1,10 @@
+export type StellarNetwork = 'testnet' | 'mainnet';
+export type DetectedStellarNetwork = 'testnet' | 'mainnet' | 'unknown';
+
+export interface WalletNetworkState {
+    expectedNetwork: StellarNetwork;
+    currentNetwork: DetectedStellarNetwork;
+    isCorrectNetwork: boolean;
+    isCheckingNetwork: boolean;
+    error: string | null;
+}


### PR DESCRIPTION
## Summary

- Implemented a dedicated "Security" tab on the user settings page (`/settings`).
- Added `ConnectedWalletCard` displaying the connected Stellar public key with copy action, toggleable full key view, and status badge.
- Added `SecurityPreferences` managing notification and security preference toggles with optimistic updates and independent loading states.
- Added `RecentSessionsList` displaying recent login sessions, highlighting the current session, with empty and loading states.
- Created `securitySettingsService`, `useSecuritySettings`, and `useRecentSessions` hooks for modular API interaction.
- Added comprehensive unit tests for all new components, services, and hooks.

## Why

Users previously lacked a centralized place to inspect their connected Stellar wallet, review active sessions, or control security-related notifications. This tab provides transparency into account activity and gives users granular control over their security preferences.

## Implementation

- **Types (`security-settings.types.ts`)**: Defined `SecurityPreferences`, `UserSession`, and `SessionStatus`.
- **Service (`security-settings.service.ts`)**: Added endpoints for `GET /users/me/security-settings`, `PATCH /users/me/security-settings`, and `GET /users/me/sessions`.
- **Hooks**:
  - `useSecuritySettings.ts`: Manages preference state, optimistic updating, and rollbacks on failure.
  - `useRecentSessions.ts`: Fetches session history with device/browser resolution.
- **Components**:
  - `ConnectedWalletCard.tsx`: Truncated address display, copy button, full key toggle, connection badge.
  - `SecurityPreferences.tsx`: Accessible toggles for security updates, login alerts, transaction alerts, escrow updates, and email notifications.
  - `RecentSessionsList.tsx`: Session cards with device info, IP, date/time, and highlighted "Current session" badge.
  - `SecurityTab.tsx`: Tab container integrated into `SettingsPage.tsx`.
- **Tests**: Comprehensive Vitest suites covering wallet address display/copying, toggle interactions, session rendering, and service calls.

## Testing

- `pnpm test`
- `pnpm lint`

## Scope / Risk

- Scoped to user settings feature (`/settings`).
- Non-breaking; falls back safely to default preferences and active session if backend endpoints are not yet seeded.

## Issue

closes #62
